### PR TITLE
test(typing): use unmarshal in YAML tests

### DIFF
--- a/tests/unit/models/test_projects.py
+++ b/tests/unit/models/test_projects.py
@@ -1855,7 +1855,7 @@ def test_get_snap_project_with_content_plugs(snapcraft_yaml, new_dir):
         },
     }
 
-    project = Project(**yaml_data)
+    project = Project.unmarshal(yaml_data)
 
     assert project.get_extra_build_snaps() == [
         "core22",
@@ -1894,7 +1894,7 @@ def test_get_snap_project_with_content_plugs_does_not_add_extension(
         },
     }
 
-    project = Project(**yaml_data)
+    project = Project.unmarshal(yaml_data)
 
     assert project.get_extra_build_snaps() == [
         "core22",
@@ -2364,7 +2364,7 @@ def test_build_planner_all_as_platform_invalid(platforms, message):
         "confinement": "strict",
     }
     with pytest.raises(pydantic.ValidationError, match=message):
-        snapcraft.models.project.Project(**build_plan_data)
+        snapcraft.models.project.Project.unmarshal(build_plan_data)
 
 
 def test_build_planner_all_with_other_builds_core22():

--- a/tests/unit/parts/test_update_metadata.py
+++ b/tests/unit/parts/test_update_metadata.py
@@ -183,7 +183,7 @@ def test_update_project_metadata_fields(
         "parts": {},
         **project_entries,
     }
-    project = Project(**yaml_data)
+    project = Project.unmarshal(yaml_data)
     metadata = ExtractedMetadata(
         version="4.5.6",
         summary="metadata summary",
@@ -250,7 +250,7 @@ def test_update_project_metadata_multiple(
         "parts": {},
         **project_entries,
     }
-    project = Project(**yaml_data)
+    project = Project.unmarshal(yaml_data)
     metadata1 = ExtractedMetadata(version="4.5.6")
     metadata2 = ExtractedMetadata(
         summary="metadata summary",
@@ -317,7 +317,7 @@ def test_update_project_metadata_overriding_appstream(new_dir):
         "source-code": "https://test.com/source-code",
         "website": "https://test.com/website",
     }
-    project = Project(**yaml_data)
+    project = Project.unmarshal(yaml_data)
     metadata = ExtractedMetadata(
         version="4.5.6",
         summary="metadata summary",
@@ -382,7 +382,7 @@ def test_update_project_metadata_icon(
     yaml_data = project_yaml_data(
         {"version": "1.0", "adopt-info": "part", "parts": {}, **project_entries}
     )
-    project = Project(**yaml_data)
+    project = Project.unmarshal(yaml_data)
     metadata = ExtractedMetadata(icon="metadata_icon.png")
 
     # create icon file
@@ -501,7 +501,7 @@ def test_update_project_metadata_desktop(
     yaml_data = project_yaml_data(
         {"version": "1.0", "adopt-info": "part", "parts": {}, **project_entries}
     )
-    project = Project(**yaml_data)
+    project = Project.unmarshal(yaml_data)
     metadata = ExtractedMetadata(
         common_id="test.id", desktop_file_paths=["metadata/foo.desktop"]
     )
@@ -544,7 +544,7 @@ def test_update_project_metadata_desktop_multiple(project_yaml_data, new_dir):
             },
         }
     )
-    project = Project(**yaml_data)
+    project = Project.unmarshal(yaml_data)
     metadata = ExtractedMetadata(
         common_id="test.id",
         desktop_file_paths=["metadata/foo.desktop", "metadata/bar.desktop"],
@@ -587,7 +587,7 @@ def test_update_project_metadata_multiple_apps(project_yaml_data, new_dir):
             },
         }
     )
-    project = Project(**yaml_data)
+    project = Project.unmarshal(yaml_data)
     metadata1 = ExtractedMetadata(
         common_id="foo.id",
         desktop_file_paths=["metadata/foo.desktop"],
@@ -625,7 +625,7 @@ def test_update_project_metadata_desktop_no_apps(project_yaml_data, new_dir):
             "parts": {},
         }
     )
-    project = Project(**yaml_data)
+    project = Project.unmarshal(yaml_data)
     metadata = ExtractedMetadata(
         common_id="test.id",
         desktop_file_paths=["metadata/foo.desktop", "metadata/bar.desktop"],


### PR DESCRIPTION
This PR cleans up `ty` typing warnings in tests by switching YAML-based test cases to use `Project.unmarshal()` instead of constructing `Project` directly.

Related to #5970.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.