### PR TITLE
fix(remotebuild): add RecipeClass

### DIFF
--- a/snapcraft/services/__init__.py
+++ b/snapcraft/services/__init__.py
@@ -24,6 +24,7 @@ from .package import Package
 from .project import Project
 from .provider import Provider
 from .confdbschemas import ConfdbSchemas
+from .remotebuild import RemoteBuild
 from .service_factory import (
     SnapcraftServiceFactory,
     register_snapcraft_services,
@@ -39,5 +40,6 @@ __all__ = [
     "Project",
     "Provider",
     "register_snapcraft_services",
+    "RemoteBuild",
     "SnapcraftServiceFactory",
 ]

--- a/snapcraft/services/remotebuild.py
+++ b/snapcraft/services/remotebuild.py
@@ -1,0 +1,25 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Snapcraft Remote Build Service."""
+
+from craft_application import launchpad
+from craft_application.services import remotebuild
+
+
+class RemoteBuild(remotebuild.RemoteBuildService):
+    """Snapcraft remote build service."""
+
+    RecipeClass = launchpad.models.SnapRecipe

--- a/snapcraft/services/service_factory.py
+++ b/snapcraft/services/service_factory.py
@@ -35,6 +35,7 @@ _SERVICES: dict[str, str] = {
     "package": "Package",
     "provider": "Provider",
     "project": "Project",
+    "remote_build": "RemoteBuild",
 }
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -639,17 +639,16 @@ def fake_remote_build_service_class(mocker):
     from craft_application import (  # noqa: PLC0415 (import-outside-top-level)
         AppMetadata,
     )
-    from craft_application.launchpad.models import (  # noqa: PLC0415 (import-outside-top-level)
-        SnapRecipe,
+
+    from snapcraft.services import (  # noqa: PLC0415 (import-outside-top-level)
+        RemoteBuild,
     )
 
     me = Mock(lazr.restfulclient.resource.Entry)
     me.name = "craft_test_user"
 
-    class FakeRemoteBuildService(craft_application.services.RemoteBuildService):
+    class FakeRemoteBuildService(RemoteBuild):
         """Fake remote build service with snap recipe."""
-
-        RecipeClass = SnapRecipe
 
         @override
         def __init__(

--- a/tests/unit/services/test_remotebuild.py
+++ b/tests/unit/services/test_remotebuild.py
@@ -1,0 +1,28 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Snapcraft Remote Build service tests."""
+
+import pytest
+from craft_application import launchpad
+
+
+@pytest.mark.usefixtures("emitter")
+def test_recipe_class(fake_services):
+    """Snapcraft should use SnapRecipes."""
+    service = fake_services.get("remote_build")
+
+    assert service.RecipeClass == launchpad.SnapRecipe


### PR DESCRIPTION
I removed the RemoteBuild service in #6010 without realizing the RecipeClass was required. I misread the spread tests failures in that PR and thought it was a launchpad issue, which was how I let the mistake get merged.

I added a unit test here to guard against future accidental removals.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
