### PR TITLE
docs: fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ Snapcraft is released under the [GPL-3.0 license](LICENSE).
 [snapcraft-site]: https://snapcraft.io/snapcraft
 [rtd-badge]: https://readthedocs.com/projects/canonical-snapcraft/badge/?version=latest
 [rtd-latest]: https://documentation.ubuntu.com/snapcraft/latest/?badge=latest
-[gha-spread-badge]: https://github.com/canonical/snapcraft/actions/workflows/spread-scheduled.yaml/badge.svg?branch=main
-[gha-spread]: https://github.com/canonical/snapcraft/actions/workflows/spread-scheduled.yaml
+[gha-spread-badge]: https://github.com/canonical/snapcraft/actions/workflows/spread-manual.yaml/badge.svg?branch=main
+[gha-spread]: https://github.com/canonical/snapcraft/actions/workflows/spread-manual.yaml
 [ruff-badge]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
 [ruff-site]: https://github.com/astral-sh/ruff
 [codecov-badge]: https://codecov.io/github/canonical/snapcraft/coverage.svg?branch=master


### PR DESCRIPTION
Fixes a broken link in the README. Thanks to @YanisaHS for catching this!

Fixes #6031 

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
