### PR TITLE
docs: remove duplicate app keys from 'snapcraft.yaml'

### DIFF
--- a/docs/reference/project-file/snapcraft-yaml.rst
+++ b/docs/reference/project-file/snapcraft-yaml.rst
@@ -216,6 +216,9 @@ App keys
 .. kitbash-field:: App restart_condition
     :prepend-name: apps.<app-name>
 
+.. kitbash-field:: App success_exit_status
+    :prepend-name: apps.<app-name>
+
 .. kitbash-field:: App install_mode
     :prepend-name: apps.<app-name>
 
@@ -232,6 +235,9 @@ App keys
     :prepend-name: apps.<app-name>
 
 .. kitbash-field:: App command_chain
+    :prepend-name: apps.<app-name>
+
+.. kitbash-field:: App sockets
     :prepend-name: apps.<app-name>
 
 .. kitbash-field:: App daemon_scope


### PR DESCRIPTION
I blame the reviewers. /s

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [X] I've successfully run `make lint && make test`.
- [X] I've added or updated any relevant documentation.
- [X] I've updated the relevant release notes.
