### PR TITLE
fix(type): update ty config for unused-ignore-comment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -390,7 +390,7 @@ exclude = [
 
 # Temporarily disabled while mypy and pyright are still in use.
 # See: https://github.com/canonical/snapcraft/issues/6007
-unused-ignore-comment = "ignore"
+unused-type-ignore-comment = "ignore"
 
 [tool.pytest.ini_options]
 minversion = "7.0"


### PR DESCRIPTION
Update `unused-ignore-comment` to `unused-type-ignore-comment` to match the configuration expected by ty ≥ 0.0.15.

Related to #5970.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
