### PR TITLE
docs: correct 'craftctl' to 'snapctl' in config doc

### DIFF
--- a/docs/explanation/snap-configurations.rst
+++ b/docs/explanation/snap-configurations.rst
@@ -35,9 +35,9 @@ configuration files.
 Interpreting options
 --------------------
 
-Internally, snaps view and change their configuration with :ref:`craftctl
-<how-to-customize-the-build-and-part-variables>` and its ``get``, ``set``, and ``unset``
-arguments.
+Internally, snaps view and change their configuration with `snapctl
+<https://snapcraft.io/docs/how-to-guides/snap-development/use-snapctl/>`__ and its
+``get``, ``set``, and ``unset`` arguments.
 
 The snapctl command works anywhere within the snap context, during execution of your
 apps and services, and in all the snap's hooks.


### PR DESCRIPTION
We'll adjust the link to intersphinx in a separate item.


---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
~~- [ ] I've updated the relevant release notes.~~
