### PR TITLE
feat: ros2 lyrical extension (core26)

### DIFF
--- a/docs/how-to/integrations/craft-an-ros-2-app.rst
+++ b/docs/how-to/integrations/craft-an-ros-2-app.rst
@@ -331,7 +331,7 @@ difference in the project file when content sharing is enabled:
 
             apps:
               ros2-talker-listener:
-                command: ros2 launch demo_nodes_cpp talker_listener.launch.py
+                command: ros2 launch demo_nodes_cpp talker_listener_launch.py
             -   extensions: [ros2-lyrical]
             +   extensions: [ros2-lyrical-ros-base]
 

--- a/docs/how-to/integrations/craft-an-ros-2-app.rst
+++ b/docs/how-to/integrations/craft-an-ros-2-app.rst
@@ -179,7 +179,7 @@ Example project file for ROS 2 Talker/Listener
 
                 apps:
                   ros2-talker-listener:
-                    command: ros2 launch demo_nodes_cpp talker_listener.launch.py
+                    command: ros2 launch demo_nodes_cpp talker_listener_launch.py
                     extensions: [ros2-lyrical]
 
 Add a ROS 2 app

--- a/docs/how-to/integrations/craft-an-ros-2-app.rst
+++ b/docs/how-to/integrations/craft-an-ros-2-app.rst
@@ -8,7 +8,7 @@ unique when crafting a `ROS 2 <https://docs.ros.org/en/rolling/index.html>`__-ba
 snap. We'll work through the aspects unique to ROS 2 apps by examining an existing
 project.
 
-There are four supported bases for ROS 2 -- core24, core22, core20, and core18.
+There are five supported bases for ROS 2 -- core26, core24, core22, core20, and core18.
 
 
 .. _how-to-craft-an-ros-2-app-project-files:
@@ -20,8 +20,8 @@ Example project file for ROS 2 Talker/Listener
 
     .. tab-item:: core18
 
-        The following code comprises the project file for the `core18 version of ROS 2
-        Talker/Listener <https://github.com/snapcraft-docs/ros2-talker-listener>`_.
+        The following code comprises the `snapcraft.yaml` file for the core18 version
+        of a ROS 2 Talker/Listener.
 
         .. dropdown:: Code
 
@@ -53,8 +53,8 @@ Example project file for ROS 2 Talker/Listener
     .. tab-item:: core20
         :sync: core20
 
-        The following code comprises the project file for the `core20 version of ROS 2
-        Talker/Listener <https://github.com/snapcraft-docs/ros2-talker-listener-core20>`_.
+        The following code comprises the `snapcraft.yaml` file for the core20 version
+        of a ROS 2 Talker/Listener.
 
         .. dropdown:: Code
 
@@ -86,8 +86,8 @@ Example project file for ROS 2 Talker/Listener
     .. tab-item:: core22
         :sync: core22
 
-        The following code comprises the project file for the `core22 version of ROS 2
-        Talker/Listener <https://github.com/snapcraft-docs/ros2-talker-listener-core22>`_.
+        The following code comprises the `snapcraft.yaml` file for the core22 version
+        of a ROS 2 Talker/Listener.
 
         .. dropdown:: Code
 
@@ -119,8 +119,8 @@ Example project file for ROS 2 Talker/Listener
     .. tab-item:: core24
         :sync: core24
 
-        The following code comprises the project file for the `core24 version of ROS 2
-        Talker/Listener <https://github.com/snapcraft-docs/ros2-talker-listener-core20>`_.
+        The following code comprises the `snapcraft.yaml` file for the core24 version
+        of a ROS 2 Talker/Listener.
 
         .. dropdown:: Code
 
@@ -149,8 +149,39 @@ Example project file for ROS 2 Talker/Listener
                     command: ros2 launch demo_nodes_cpp talker_listener_launch.py
                     extensions: [ros2-jazzy]
 
+    .. group-tab:: core26
 
-Add an ROS 2 app
+        The following code comprises the `snapcraft.yaml` file for the core26 version
+        of a ROS 2 Talker/Listener.
+
+        .. collapse:: Code
+
+            .. code-block:: yaml
+                :caption: snapcraft.yaml
+
+                name: ros2-talker-listener
+                version: '0.1'
+                summary: ROS 2 Talker/Listener Example
+                description: |
+                  This example launches a ROS 2 talker and listener.
+
+                confinement: devmode
+                base: core26
+
+                parts:
+                  ros-demos:
+                    plugin: colcon
+                    source: https://github.com/ros2/demos.git
+                    source-branch: lyrical
+                    source-subdir: demo_nodes_cpp
+                    stage-packages: [ros-lyrical-ros2launch]
+
+                apps:
+                  ros2-talker-listener:
+                    command: ros2 launch demo_nodes_cpp talker_listener.launch.py
+                    extensions: [ros2-lyrical]
+
+Add a ROS 2 app
 ----------------
 
 ROS 2 apps depend on special extensions that initialize the build- and run-time
@@ -174,6 +205,8 @@ To add an ROS 2 app:
         - :ref:`ros2-humble <reference-ros-2-extensions>`
       * - core24
         - :ref:`ros2-jazzy <reference-ros-2-extensions>`
+      * - core26
+        - :ref:`ros2-lyrical <reference-ros-2-extensions>`
 
 
 Add a part written for ROS 2
@@ -207,6 +240,8 @@ To add an ROS 2 part:
         - ros-humble-ros2launch
       * - core24
         - ros-jazzy-ros2launch
+      * - core26
+        - ros-lyrical-ros2launch
 
 
 Handle build issues
@@ -225,7 +260,7 @@ false positives. These libraries are build time dependencies only.
 Share content between ROS 2 snaps
 ---------------------------------
 
-The core20, core22 and core24 bases also offer the option to build your ROS snap using
+The core20, core22, core24 and core26 bases also offer the option to build your ROS snap using
 the :external+snap:ref:`interfaces-content-interface`. It shares the ROS 2 content
 packages across multiple snaps, saving space and ensuring package consistency throughout
 your snap build environment.
@@ -284,6 +319,20 @@ difference in the project file when content sharing is enabled:
             -   extensions: [ros2-jazzy]
             +   extensions: [ros2-jazzy-ros-base]
 
+    .. group-tab:: core26
+
+        .. code-block:: diff
+            :caption: snapcraft.yaml
+
+            source-subdir: demo_nodes_cpp
+            -  stage-packages: [ros-lyrical-ros2launch]
+
+            apps:
+              ros2-talker-listener:
+                command: ros2 launch demo_nodes_cpp talker_listener.launch.py
+            -   extensions: [ros2-lyrical]
+            +   extensions: [ros2-lyrical-ros-base]
+
 To turn on content sharing:
 
 #. Remove the ``stage-packages`` key from the part. The package is already available in
@@ -302,6 +351,8 @@ To turn on content sharing:
         - :ref:`ros2-humble-ros-base <reference-ros-2-content-extensions>`
       * - core24
         - :ref:`ros2-jazzy-ros-base <reference-ros-2-content-extensions>`
+      * - core26
+        - :ref:`ros2-lyrical-ros-base <reference-ros-2-content-extensions>`
 
 
 Because the snap makes use of the content provided by another snap, you must connect

--- a/docs/how-to/integrations/craft-an-ros-2-app.rst
+++ b/docs/how-to/integrations/craft-an-ros-2-app.rst
@@ -149,12 +149,13 @@ Example project file for ROS 2 Talker/Listener
                     command: ros2 launch demo_nodes_cpp talker_listener_launch.py
                     extensions: [ros2-jazzy]
 
-    .. group-tab:: core26
+    .. tab-item:: core26
+        :sync: core26
 
         The following code comprises the `snapcraft.yaml` file for the core26 version
         of a ROS 2 Talker/Listener.
 
-        .. collapse:: Code
+        .. dropdown:: Code
 
             .. code-block:: yaml
                 :caption: snapcraft.yaml
@@ -319,7 +320,8 @@ difference in the project file when content sharing is enabled:
             -   extensions: [ros2-jazzy]
             +   extensions: [ros2-jazzy-ros-base]
 
-    .. group-tab:: core26
+    .. tab-item:: core26
+        :sync: core26
 
         .. code-block:: diff
             :caption: snapcraft.yaml

--- a/docs/how-to/integrations/craft-an-ros-2-app.rst
+++ b/docs/how-to/integrations/craft-an-ros-2-app.rst
@@ -20,7 +20,7 @@ Example project file for ROS 2 Talker/Listener
 
     .. tab-item:: core18
 
-        The following code comprises the `snapcraft.yaml` file for the core18 version
+        The following code comprises the project file for the core18 version
         of a ROS 2 Talker/Listener.
 
         .. dropdown:: Code
@@ -53,7 +53,7 @@ Example project file for ROS 2 Talker/Listener
     .. tab-item:: core20
         :sync: core20
 
-        The following code comprises the `snapcraft.yaml` file for the core20 version
+        The following code comprises the project file for the core20 version
         of a ROS 2 Talker/Listener.
 
         .. dropdown:: Code
@@ -86,7 +86,7 @@ Example project file for ROS 2 Talker/Listener
     .. tab-item:: core22
         :sync: core22
 
-        The following code comprises the `snapcraft.yaml` file for the core22 version
+        The following code comprises the project file for the core22 version
         of a ROS 2 Talker/Listener.
 
         .. dropdown:: Code
@@ -119,7 +119,7 @@ Example project file for ROS 2 Talker/Listener
     .. tab-item:: core24
         :sync: core24
 
-        The following code comprises the `snapcraft.yaml` file for the core24 version
+        The following code comprises the project file for the core24 version
         of a ROS 2 Talker/Listener.
 
         .. dropdown:: Code
@@ -152,7 +152,7 @@ Example project file for ROS 2 Talker/Listener
     .. tab-item:: core26
         :sync: core26
 
-        The following code comprises the `snapcraft.yaml` file for the core26 version
+        The following code comprises the project file for the core26 version
         of a ROS 2 Talker/Listener.
 
         .. dropdown:: Code

--- a/docs/reference/extensions/code/ros-2-lyrical-extension-talker-listener-expanded.diff
+++ b/docs/reference/extensions/code/ros-2-lyrical-extension-talker-listener-expanded.diff
@@ -1,0 +1,74 @@
+# Diff between snapcraft.yaml and `snapcraft expand-extensions`, showing the differences
+# that the ROS 2 Lyrical extension applies to a project file.
+ name: ros2-talker-listener
+ version: "0.1"
+ summary: ROS 2 Talker/Listener Example
+ description: |
+   This example launches a ROS 2 talker and listener.
+
+ confinement: devmode
+ base: core26
+
+ parts:
+   ros-demos:
+     plugin: colcon
+     source: https://github.com/ros2/demos.git
+     source-branch: lyrical
+     source-subdir: demo_nodes_cpp
+     stage-packages:
+       - ros-lyrical-ros2launch
++    build-environment:
++      - ROS_VERSION: "2"
++      - ROS_DISTRO: lyrical
++  ros2-lyrical/ros2-launch:
++    source: /snap/snapcraft/current/share/snapcraft/extensions/ros2
++    plugin: make
++    build-packages:
++      - ros-lyrical-ros-environment
++      - ros-lyrical-ros-workspace
++      - ros-lyrical-ament-index-cpp
++      - ros-lyrical-ament-index-python
+
+ apps:
+   ros2-talker-listener:
+     command: ros2 launch demo_nodes_cpp talker_listener.launch.py
+-    extensions:
+-      - ros2-lyrical
++    environment:
++      ROS_VERSION: "2"
++      ROS_DISTRO: lyrical
++      PYTHONPATH: $SNAP/opt/ros/lyrical/lib/python3.14/site-packages:$SNAP/usr/lib/python3/dist-packages:${PYTHONPATH}
++      ROS_HOME: $SNAP_USER_DATA/ros
++    command-chain:
++      - snap/command-chain/ros2-launch
++
++package-repositories:
++  - type: apt
++    url: http://packages.ros.org/ros2/ubuntu
++    components:
++      - main
++    formats:
++      - deb
++    key-id: C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
++    key-server: keyserver.ubuntu.com
++    suites:
++      - resolute
++
++lint:
++  ignore:
++    - unused-library:
++        - opt/ros/*
++        - lib/*/libcrypt.so*
++        - lib/*/libexpat.so*
++        - lib/*/libtirpc.so*
++        - lib/*/libz.so*
++        - usr/lib/*libatomic.so*
++        - usr/lib/*libconsole_bridge.so*
++        - usr/lib/*libfmt.so*
++        - usr/lib/*libicui18n.so*
++        - usr/lib/*libicuio.so*
++        - usr/lib/*libicutest.so*
++        - usr/lib/*libicutu.so*
++        - usr/lib/*libpython3.14.so*
++        - usr/lib/*libspdlog.so*
++        - usr/lib/*libtinyxml2.so*

--- a/docs/reference/extensions/code/ros-2-lyrical-extension-talker-listener-expanded.diff
+++ b/docs/reference/extensions/code/ros-2-lyrical-extension-talker-listener-expanded.diff
@@ -31,7 +31,7 @@
 
  apps:
    ros2-talker-listener:
-     command: ros2 launch demo_nodes_cpp talker_listener.launch.py
+     command: ros2 launch demo_nodes_cpp talker_listener_launch.py
 -    extensions:
 -      - ros2-lyrical
 +    environment:

--- a/docs/reference/extensions/code/ros-2-lyrical-extension-talker-listener-expanded.diff
+++ b/docs/reference/extensions/code/ros-2-lyrical-extension-talker-listener-expanded.diff
@@ -38,6 +38,7 @@
 +      ROS_VERSION: "2"
 +      ROS_DISTRO: lyrical
 +      PYTHONPATH: $SNAP/opt/ros/lyrical/lib/python3.14/site-packages:$SNAP/usr/lib/python3/dist-packages:${PYTHONPATH}
++      LD_LIBRARY_PATH: $SNAP/usr/lib/x86_64-linux-gnu/blas:$SNAP/usr/lib/x86_64-linux-gnu/lapack:$SNAP/usr/lib/aarch64-linux-gnu/blas:$SNAP/usr/lib/aarch64-linux-gnu/lapack:$SNAP/usr/lib/arm-linux-gnueabihf/blas:$SNAP/usr/lib/arm-linux-gnueabihf/lapack:${LD_LIBRARY_PATH}
 +      ROS_HOME: $SNAP_USER_DATA/ros
 +    command-chain:
 +      - snap/command-chain/ros2-launch

--- a/docs/reference/extensions/ros-2-content-extensions.rst
+++ b/docs/reference/extensions/ros-2-content-extensions.rst
@@ -29,6 +29,12 @@ with the format ``ros2-<version>-<metapackage>``. The available extensions are:
         - ``ros2-jazzy-ros-base``
         - ``ros2-jazzy-desktop``
 
+    .. group-tab:: ROS 2 Lyrical
+
+        - ``ros2-lyrical-ros-core``
+        - ``ros2-lyrical-ros-base``
+        - ``ros2-lyrical-desktop``
+
 These extensions require Snapcraft 8 and higher, and are experimental.
 
 

--- a/docs/reference/extensions/ros-2-content-extensions.rst
+++ b/docs/reference/extensions/ros-2-content-extensions.rst
@@ -29,7 +29,7 @@ with the format ``ros2-<version>-<metapackage>``. The available extensions are:
         - ``ros2-jazzy-ros-base``
         - ``ros2-jazzy-desktop``
 
-    .. group-tab:: ROS 2 Lyrical
+    .. tab-item:: ROS 2 Lyrical
 
         - ``ros2-lyrical-ros-core``
         - ``ros2-lyrical-ros-base``

--- a/docs/reference/extensions/ros-2-content-extensions.rst
+++ b/docs/reference/extensions/ros-2-content-extensions.rst
@@ -35,7 +35,8 @@ with the format ``ros2-<version>-<metapackage>``. The available extensions are:
         - ``ros2-lyrical-ros-base``
         - ``ros2-lyrical-desktop``
 
-These extensions require Snapcraft 8 and higher, and are experimental.
+The Humble and Jazzy extensions require Snapcraft 8 and higher, and the Lyrical
+extensions require Snapcraft 9 and higher. These extensions are experimental.
 
 
 Included interface connections

--- a/docs/reference/extensions/ros-2-extensions.rst
+++ b/docs/reference/extensions/ros-2-extensions.rst
@@ -99,9 +99,10 @@ The extension adds its own part to the project, which pulls in the ROS 2 build p
                     - ros-jazzy-ament-index-cpp
                     - ros-jazzy-ament-index-python
 
-    .. group-tab:: ROS 2 Lyrical
+    .. tab-item:: ROS 2 Lyrical
+        :sync: lyrical
 
-        .. collapse:: Included parts
+        .. dropdown:: Included parts
 
             .. code-block:: yaml
                 :caption: snapcraft.yaml
@@ -160,9 +161,10 @@ variables.
                   - ROS_VERSION: "2"
                   - ROS_DISTRO: jazzy
 
-    .. group-tab:: ROS 2 Lyrical
+    .. tab-item:: ROS 2 Lyrical
+        :sync: lyrical
 
-        .. collapse:: Included build environment variables
+        .. dropdown:: Included build environment variables
 
             .. code-block:: yaml
                 :caption: snapcraft.yaml
@@ -315,9 +317,10 @@ installs the necessary GPG key.
                     suites:
                       - noble
 
-    .. group-tab:: ROS 2 Lyrical
+    .. tab-item:: ROS 2 Lyrical
+        :sync: lyrical
 
-        .. collapse:: Included package repositories
+        .. dropdown:: Included package repositories
 
             .. code-block:: yaml
                 :caption: snapcraft.yaml
@@ -381,9 +384,10 @@ The files are based on the :ref:`ros2-talker-listener
                 :lines: 3-
                 :emphasize-lines: 18-28, 33-41, 43-53
 
-    .. group-tab:: ROS 2 Lyrical
+    .. tab-item:: ROS 2 Lyrical
+        :sync: lyrical
 
-        .. collapse:: Expanded project file for ros2-talker-listener
+        .. dropdown:: Expanded project file for ros2-talker-listener
 
             .. literalinclude:: code/ros-2-lyrical-extension-talker-listener-expanded.diff
                 :language: diff

--- a/docs/reference/extensions/ros-2-extensions.rst
+++ b/docs/reference/extensions/ros-2-extensions.rst
@@ -7,7 +7,7 @@ ROS 2 extensions
 The ROS 2 extensions, helps fill in common settings for software built with the  `ROS 2
 <https://ros.org>`_ libraries.
 
-There are three extensions in this family, each for a different version of ROS 2.
+There are four extensions in this family, each for a different version of ROS 2.
 
 .. list-table::
 
@@ -31,9 +31,14 @@ There are three extensions in this family, each for a different version of ROS 2
       - :ref:`ROS 2 Jazzy Jalisco <reference-ros-2-content-extensions>`
       - core24
 
+    * - ROS 2 Lyrical
+      - ``ros2-lyrical``
+      - :ref:`ROS 2 Lyrical Luth <reference-ros-2-content-extensions>`
+      - core26
+
         :ref:`Experimental extensions enabled <how-to-enable-experimental-extensions>`
 
-All three extensions require Snapcraft 7.3 or higher.
+All four extensions require Snapcraft 7.3 or higher.
 
 
 Included parts
@@ -69,7 +74,7 @@ The extension adds its own part to the project, which pulls in the ROS 2 build p
                 :caption: snapcraft.yaml
 
                 ros2-humble/ros2-launch:
-                  source: /snap/snapcraft/13181/share/snapcraft/extensions/ros2
+                  source: /snap/snapcraft/current/share/snapcraft/extensions/ros2
                   plugin: make
                   build-packages:
                     - ros-humble-ros-environment
@@ -86,13 +91,29 @@ The extension adds its own part to the project, which pulls in the ROS 2 build p
                 :caption: snapcraft.yaml
 
                 ros2-jazzy/ros2-launch:
-                  source: /snap/snapcraft/13181/share/snapcraft/extensions/ros2
+                  source: /snap/snapcraft/current/share/snapcraft/extensions/ros2
                   plugin: make
                   build-packages:
                     - ros-jazzy-ros-environment
                     - ros-jazzy-ros-workspace
                     - ros-jazzy-ament-index-cpp
                     - ros-jazzy-ament-index-python
+
+    .. group-tab:: ROS 2 Lyrical
+
+        .. collapse:: Included parts
+
+            .. code-block:: yaml
+                :caption: snapcraft.yaml
+
+                ros2-lyrical/ros2-launch:
+                  source: /snap/snapcraft/current/share/snapcraft/extensions/ros2
+                  plugin: make
+                  build-packages:
+                    - ros-lyrical-ros-environment
+                    - ros-lyrical-ros-workspace
+                    - ros-lyrical-ament-index-cpp
+                    - ros-lyrical-ament-index-python
 
 
 Included build environment variables
@@ -138,6 +159,17 @@ variables.
                 build-environment:
                   - ROS_VERSION: "2"
                   - ROS_DISTRO: jazzy
+
+    .. group-tab:: ROS 2 Lyrical
+
+        .. collapse:: Included build environment variables
+
+            .. code-block:: yaml
+                :caption: snapcraft.yaml
+
+                build-environment:
+                  - ROS_VERSION: "2"
+                  - ROS_DISTRO: lyrical
 
 
 Included runtime environment settings
@@ -193,6 +225,22 @@ ROS 2 before launching the app, similar to sourcing the typical ROS 2
                   ROS_VERSION: "2"
                   ROS_DISTRO: jazzy
                   PYTHONPATH: $SNAP/opt/ros/jazzy/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:${PYTHONPATH}
+                  ROS_HOME: $SNAP_USER_DATA/ros
+                command-chain:
+                  - snap/command-chain/ros2-launch
+
+    .. tab-item:: ROS 2 Lyrical
+        :sync: lyrical
+
+        .. dropdown:: Included runtime environment settings
+
+            .. code-block:: yaml
+                :caption: snapcraft.yaml
+
+                environment:
+                  ROS_VERSION: "2"
+                  ROS_DISTRO: lyrical
+                  PYTHONPATH: $SNAP/opt/ros/lyrical/lib/python3.14/site-packages:$SNAP/usr/lib/python3/dist-packages:${PYTHONPATH}
                   ROS_HOME: $SNAP_USER_DATA/ros
                 command-chain:
                   - snap/command-chain/ros2-launch
@@ -267,6 +315,25 @@ installs the necessary GPG key.
                     suites:
                       - noble
 
+    .. group-tab:: ROS 2 Lyrical
+
+        .. collapse:: Included package repositories
+
+            .. code-block:: yaml
+                :caption: snapcraft.yaml
+
+                package-repositories:
+                  - type: apt
+                    url: http://packages.ros.org/ros2/ubuntu
+                    components:
+                      - main
+                    formats:
+                      - deb
+                    key-id: C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+                    key-server: keyserver.ubuntu.com
+                    suites:
+                      - resolute
+
 
 Example expanded project file
 -----------------------------
@@ -310,6 +377,15 @@ The files are based on the :ref:`ros2-talker-listener
         .. dropdown:: Expanded project file for ros2-talker-listener
 
             .. literalinclude:: code/ros-2-jazzy-extension-talker-listener-expanded.diff
+                :language: diff
+                :lines: 3-
+                :emphasize-lines: 18-28, 33-41, 43-53
+
+    .. group-tab:: ROS 2 Lyrical
+
+        .. collapse:: Expanded project file for ros2-talker-listener
+
+            .. literalinclude:: code/ros-2-lyrical-extension-talker-listener-expanded.diff
                 :language: diff
                 :lines: 3-
                 :emphasize-lines: 18-28, 33-41, 43-53

--- a/docs/reference/extensions/ros-2-extensions.rst
+++ b/docs/reference/extensions/ros-2-extensions.rst
@@ -243,6 +243,7 @@ ROS 2 before launching the app, similar to sourcing the typical ROS 2
                   ROS_VERSION: "2"
                   ROS_DISTRO: lyrical
                   PYTHONPATH: $SNAP/opt/ros/lyrical/lib/python3.14/site-packages:$SNAP/usr/lib/python3/dist-packages:${PYTHONPATH}
+                  LD_LIBRARY_PATH: $SNAP/usr/lib/x86_64-linux-gnu/blas:$SNAP/usr/lib/x86_64-linux-gnu/lapack:$SNAP/usr/lib/aarch64-linux-gnu/blas:$SNAP/usr/lib/aarch64-linux-gnu/lapack:$SNAP/usr/lib/arm-linux-gnueabihf/blas:$SNAP/usr/lib/arm-linux-gnueabihf/lapack:${LD_LIBRARY_PATH}
                   ROS_HOME: $SNAP_USER_DATA/ros
                 command-chain:
                   - snap/command-chain/ros2-launch

--- a/docs/reference/extensions/ros-2-extensions.rst
+++ b/docs/reference/extensions/ros-2-extensions.rst
@@ -38,7 +38,7 @@ There are four extensions in this family, each for a different version of ROS 2.
 
         :ref:`Experimental extensions enabled <how-to-enable-experimental-extensions>`
 
-All four extensions require Snapcraft 7.3 or higher.
+The Foxy, Humble, and Jazzy extensions require Snapcraft 7.3 or higher; Lyrical requires Snapcraft 9 or higher.
 
 
 Included parts

--- a/snapcraft/extensions/_ros2_lyrical_meta.py
+++ b/snapcraft/extensions/_ros2_lyrical_meta.py
@@ -1,0 +1,118 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Base for ROS 2 Lyrical extensions to the Colcon plugin using content-sharing."""
+
+import dataclasses
+from abc import abstractmethod
+from typing import Any
+
+from overrides import overrides
+
+from .ros2_lyrical import ROS2LyricalExtension
+
+
+@dataclasses.dataclass
+class ROS2LyricalSnaps:
+    """A structure of ROS 2 Lyrical related snaps."""
+
+    sdk: str
+    content: str
+    variant: str
+
+
+class ROS2LyricalMetaBase(ROS2LyricalExtension):
+    """Drives ROS 2 build and runtime environment for snap using content-sharing."""
+
+    @property
+    @abstractmethod
+    def ros2_lyrical_snaps(self) -> ROS2LyricalSnaps:
+        """Return the ROS 2 Lyrical related snaps to use to construct the environment."""
+        raise NotImplementedError
+
+    @staticmethod
+    @overrides
+    def is_experimental(base: str | None) -> bool:
+        return True
+
+    @overrides
+    def get_root_snippet(self) -> dict[str, Any]:
+        root_snippet = super().get_root_snippet()
+        root_snippet["plugs"] = {
+            self.ros2_lyrical_snaps.content: {
+                "interface": "content",
+                "content": self.ros2_lyrical_snaps.content,
+                "target": "$SNAP/opt/ros/underlay_ws",
+                "default-provider": self.ros2_lyrical_snaps.content,
+            }
+        }
+        return root_snippet
+
+    @overrides
+    def get_app_snippet(self, *, app_name: str) -> dict[str, Any]:
+        app_snippet = super().get_app_snippet(app_name=app_name)
+        python_paths = app_snippet["environment"]["PYTHONPATH"]
+        new_python_paths = [
+            f"$SNAP/opt/ros/underlay_ws/opt/ros/{self.ROS_DISTRO}/lib/python3.14/site-packages",
+            "$SNAP/opt/ros/underlay_ws/usr/lib/python3/dist-packages",
+        ]
+
+        app_snippet["environment"]["PYTHONPATH"] = (
+            f"{python_paths}:{':'.join(new_python_paths)}"
+        )
+
+        return app_snippet
+
+    @overrides
+    def get_part_snippet(self, *, plugin_name: str) -> dict[str, Any]:
+        part_snippet = super().get_part_snippet(plugin_name=plugin_name)
+
+        # These are colcon-plugin specific entries
+        if plugin_name == "colcon":
+            part_snippet["colcon-ros-build-snaps"] = [self.ros2_lyrical_snaps.sdk]
+            part_snippet["colcon-cmake-args"] = [
+                f'-DCMAKE_SYSTEM_PREFIX_PATH="/snap/{self.ros2_lyrical_snaps.sdk}/current/usr"'
+            ]
+
+        return part_snippet
+
+    @overrides
+    def get_parts_snippet(self) -> dict[str, Any]:
+        parts_snippet = super().get_parts_snippet()
+        # Very unlikely but it may happen that the snapped application doesn't
+        # even pull those deps. In that case, there is no valid ROS 2 ws to source.
+        # We make sure here that they are staged no matter what.
+        parts_snippet[f"ros2-{self.ROS_DISTRO}/ros2-launch"]["stage-packages"] = [
+            f"ros-{self.ROS_DISTRO}-ros-environment",
+            f"ros-{self.ROS_DISTRO}-ros-workspace",
+            f"ros-{self.ROS_DISTRO}-ament-index-cpp",
+            f"ros-{self.ROS_DISTRO}-ament-index-python",
+        ]
+
+        # Something in the ROS 2 build chain requires to find this lib during cmake call,
+        # however its cmake files ship with the '-dev' package.
+        # TODO: Check if this is still needed in 26.04, the Python/CMake integration may have changed
+        parts_snippet[f"ros2-{self.ROS_DISTRO}/ros2-launch"]["build-packages"].append(
+            "libpython3.14-dev"
+        )
+
+        # The part name must follow the format <extension-name>/<part-name>
+        parts_snippet[
+            f"ros2-{self.ROS_DISTRO}-{self.ros2_lyrical_snaps.variant}/ros2-launch"
+        ] = parts_snippet[f"ros2-{self.ROS_DISTRO}/ros2-launch"]
+        parts_snippet.pop(f"ros2-{self.ROS_DISTRO}/ros2-launch")
+
+        return parts_snippet

--- a/snapcraft/extensions/_ros2_lyrical_meta.py
+++ b/snapcraft/extensions/_ros2_lyrical_meta.py
@@ -82,7 +82,9 @@ class ROS2LyricalMetaBase(ROS2LyricalExtension):
 
         # These are colcon-plugin specific entries
         if plugin_name == "colcon":
-            part_snippet["colcon-ros-build-snaps"] = [self.ros2_lyrical_snaps.sdk]
+            part_snippet["colcon-ros-build-snaps"] = [
+                f"{self.ros2_lyrical_snaps.sdk}/edge"
+            ]
             part_snippet["colcon-cmake-args"] = [
                 f'-DCMAKE_SYSTEM_PREFIX_PATH="/snap/{self.ros2_lyrical_snaps.sdk}/current/usr"'
             ]
@@ -100,6 +102,12 @@ class ROS2LyricalMetaBase(ROS2LyricalExtension):
             f"ros-{self.ROS_DISTRO}-ros-workspace",
             f"ros-{self.ROS_DISTRO}-ament-index-cpp",
             f"ros-{self.ROS_DISTRO}-ament-index-python",
+            "libpython3.14-minimal",
+            "libpython3.14-stdlib",
+            "python3-minimal",  # for the "python3" symlink
+            "python3.14-minimal",
+            "python3.14-venv",
+            "python3-yaml",
         ]
 
         # Something in the ROS 2 build chain requires to find this lib during cmake call,

--- a/snapcraft/extensions/_ros2_lyrical_meta.py
+++ b/snapcraft/extensions/_ros2_lyrical_meta.py
@@ -74,6 +74,19 @@ class ROS2LyricalMetaBase(ROS2LyricalExtension):
             f"{python_paths}:{':'.join(new_python_paths)}"
         )
 
+        ld_library_path = app_snippet["environment"]["LD_LIBRARY_PATH"]
+        underlay_ld_paths = [
+            "$SNAP/opt/ros/underlay_ws/usr/lib/x86_64-linux-gnu/blas",
+            "$SNAP/opt/ros/underlay_ws/usr/lib/x86_64-linux-gnu/lapack",
+            "$SNAP/opt/ros/underlay_ws/usr/lib/aarch64-linux-gnu/blas",
+            "$SNAP/opt/ros/underlay_ws/usr/lib/aarch64-linux-gnu/lapack",
+            "$SNAP/opt/ros/underlay_ws/usr/lib/arm-linux-gnueabihf/blas",
+            "$SNAP/opt/ros/underlay_ws/usr/lib/arm-linux-gnueabihf/lapack",
+        ]
+        app_snippet["environment"]["LD_LIBRARY_PATH"] = (
+            f"{ld_library_path}:{':'.join(underlay_ld_paths)}"
+        )
+
         return app_snippet
 
     @overrides

--- a/snapcraft/extensions/_ros2_lyrical_meta.py
+++ b/snapcraft/extensions/_ros2_lyrical_meta.py
@@ -95,9 +95,7 @@ class ROS2LyricalMetaBase(ROS2LyricalExtension):
 
         # These are colcon-plugin specific entries
         if plugin_name == "colcon":
-            part_snippet["colcon-ros-build-snaps"] = [
-                self.ros2_lyrical_snaps.sdk
-            ]
+            part_snippet["colcon-ros-build-snaps"] = [self.ros2_lyrical_snaps.sdk]
             part_snippet["colcon-cmake-args"] = [
                 f'-DCMAKE_SYSTEM_PREFIX_PATH="/snap/{self.ros2_lyrical_snaps.sdk}/current/usr"'
             ]

--- a/snapcraft/extensions/_ros2_lyrical_meta.py
+++ b/snapcraft/extensions/_ros2_lyrical_meta.py
@@ -83,7 +83,7 @@ class ROS2LyricalMetaBase(ROS2LyricalExtension):
         # These are colcon-plugin specific entries
         if plugin_name == "colcon":
             part_snippet["colcon-ros-build-snaps"] = [
-                f"{self.ros2_lyrical_snaps.sdk}/edge"
+                self.ros2_lyrical_snaps.sdk
             ]
             part_snippet["colcon-cmake-args"] = [
                 f'-DCMAKE_SYSTEM_PREFIX_PATH="/snap/{self.ros2_lyrical_snaps.sdk}/current/usr"'

--- a/snapcraft/extensions/_ros2_lyrical_meta.py
+++ b/snapcraft/extensions/_ros2_lyrical_meta.py
@@ -113,13 +113,7 @@ class ROS2LyricalMetaBase(ROS2LyricalExtension):
             f"ros-{self.ROS_DISTRO}-ros-workspace",
             f"ros-{self.ROS_DISTRO}-ament-index-cpp",
             f"ros-{self.ROS_DISTRO}-ament-index-python",
-            "libpython3.14-minimal",
-            "libpython3.14-stdlib",
-            "python3-minimal",  # for the "python3" symlink
-            "python3.14-minimal",
-            "python3.14-venv",
-            "python3-yaml",
-        ]
+        ] + parts_snippet[f"ros2-{self.ROS_DISTRO}/ros2-launch"]["stage-packages"]
 
         # Something in the ROS 2 build chain requires to find this lib during cmake call,
         # however its cmake files ship with the '-dev' package.

--- a/snapcraft/extensions/_ros2_lyrical_meta.py
+++ b/snapcraft/extensions/_ros2_lyrical_meta.py
@@ -20,7 +20,7 @@ import dataclasses
 from abc import abstractmethod
 from typing import Any
 
-from overrides import overrides
+from typing_extensions import override
 
 from .ros2_lyrical import ROS2LyricalExtension
 
@@ -44,11 +44,11 @@ class ROS2LyricalMetaBase(ROS2LyricalExtension):
         raise NotImplementedError
 
     @staticmethod
-    @overrides
+    @override
     def is_experimental(base: str | None) -> bool:
         return True
 
-    @overrides
+    @override
     def get_root_snippet(self) -> dict[str, Any]:
         root_snippet = super().get_root_snippet()
         root_snippet["plugs"] = {
@@ -61,7 +61,7 @@ class ROS2LyricalMetaBase(ROS2LyricalExtension):
         }
         return root_snippet
 
-    @overrides
+    @override
     def get_app_snippet(self, *, app_name: str) -> dict[str, Any]:
         app_snippet = super().get_app_snippet(app_name=app_name)
         python_paths = app_snippet["environment"]["PYTHONPATH"]
@@ -89,7 +89,7 @@ class ROS2LyricalMetaBase(ROS2LyricalExtension):
 
         return app_snippet
 
-    @overrides
+    @override
     def get_part_snippet(self, *, plugin_name: str) -> dict[str, Any]:
         part_snippet = super().get_part_snippet(plugin_name=plugin_name)
 
@@ -102,7 +102,7 @@ class ROS2LyricalMetaBase(ROS2LyricalExtension):
 
         return part_snippet
 
-    @overrides
+    @override
     def get_parts_snippet(self) -> dict[str, Any]:
         parts_snippet = super().get_parts_snippet()
         # Very unlikely but it may happen that the snapped application doesn't

--- a/snapcraft/extensions/_ros2_lyrical_meta.py
+++ b/snapcraft/extensions/_ros2_lyrical_meta.py
@@ -117,7 +117,6 @@ class ROS2LyricalMetaBase(ROS2LyricalExtension):
 
         # Something in the ROS 2 build chain requires to find this lib during cmake call,
         # however its cmake files ship with the '-dev' package.
-        # TODO: Check if this is still needed in 26.04, the Python/CMake integration may have changed
         parts_snippet[f"ros2-{self.ROS_DISTRO}/ros2-launch"]["build-packages"].append(
             "libpython3.14-dev"
         )

--- a/snapcraft/extensions/registry.py
+++ b/snapcraft/extensions/registry.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2026 Canonical Ltd.
+# Copyright 2018-2022 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/snapcraft/extensions/registry.py
+++ b/snapcraft/extensions/registry.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2018-2022 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -37,6 +37,10 @@ from .ros2_jazzy import ROS2JazzyExtension
 from .ros2_jazzy_desktop import ROS2JazzyDesktopExtension
 from .ros2_jazzy_ros_base import ROS2JazzyRosBaseExtension
 from .ros2_jazzy_ros_core import ROS2JazzyRosCoreExtension
+from .ros2_lyrical import ROS2LyricalExtension
+from .ros2_lyrical_desktop import ROS2LyricalDesktopExtension
+from .ros2_lyrical_ros_base import ROS2LyricalRosBaseExtension
+from .ros2_lyrical_ros_core import ROS2LyricalRosCoreExtension
 
 if TYPE_CHECKING:
     from .extension import Extension
@@ -58,6 +62,10 @@ _EXTENSIONS: dict[str, "ExtensionType"] = {
     "ros2-jazzy-ros-core": ROS2JazzyRosCoreExtension,
     "ros2-jazzy-ros-base": ROS2JazzyRosBaseExtension,
     "ros2-jazzy-desktop": ROS2JazzyDesktopExtension,
+    "ros2-lyrical": ROS2LyricalExtension,
+    "ros2-lyrical-ros-core": ROS2LyricalRosCoreExtension,
+    "ros2-lyrical-ros-base": ROS2LyricalRosBaseExtension,
+    "ros2-lyrical-desktop": ROS2LyricalDesktopExtension,
     "kde-neon": KDENeon,
     "kde-neon-6": KDENeon6,
     "kde-neon-qt6": KDENeonQt6,

--- a/snapcraft/extensions/ros2_lyrical.py
+++ b/snapcraft/extensions/ros2_lyrical.py
@@ -1,0 +1,127 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Extension to the Colcon plugin for ROS 2 Lyrical."""
+
+from typing import Any, Final
+
+from overrides import overrides
+
+from .extension import Extension, get_extensions_data_dir
+
+
+class ROS2LyricalExtension(Extension):
+    """Drives ROS 2 build and runtime environment for snap."""
+
+    ROS_VERSION: Final[str] = "2"
+    ROS_DISTRO: Final[str] = "lyrical"
+
+    @staticmethod
+    @overrides
+    def get_supported_bases() -> tuple[str, ...]:
+        return ("core26",)
+
+    @staticmethod
+    @overrides
+    def get_supported_confinement() -> tuple[str, ...]:
+        return ("strict", "devmode")
+
+    @staticmethod
+    @overrides
+    def is_experimental(base: str | None) -> bool:
+        return True
+
+    @overrides
+    def get_root_snippet(self) -> dict[str, Any]:
+        return {
+            "package-repositories": [
+                {
+                    "type": "apt",
+                    "url": "http://packages.ros.org/ros2/ubuntu",
+                    "components": ["main"],
+                    "formats": ["deb"],
+                    "key-id": "C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654",
+                    "key-server": "keyserver.ubuntu.com",
+                    "suites": ["resolute"],
+                }
+            ],
+            "lint": {
+                "ignore": [
+                    {
+                        "unused-library": [
+                            "opt/ros/*",
+                            "lib/*/libcrypt.so*",
+                            "lib/*/libexpat.so*",
+                            "lib/*/libtirpc.so*",
+                            "lib/*/libz.so*",
+                            "usr/lib/*libatomic.so*",
+                            "usr/lib/*libconsole_bridge.so*",
+                            "usr/lib/*libfmt.so*",
+                            "usr/lib/*libicui18n.so*",
+                            "usr/lib/*libicuio.so*",
+                            "usr/lib/*libicutest.so*",
+                            "usr/lib/*libicutu.so*",
+                            "usr/lib/*libpython3.14.so*",
+                            "usr/lib/*libspdlog.so*",
+                            "usr/lib/*libtinyxml2.so*",
+                        ]
+                    }
+                ]
+            },
+        }
+
+    @overrides
+    def get_app_snippet(self, *, app_name: str) -> dict[str, Any]:
+        python_paths = [
+            f"$SNAP/opt/ros/{self.ROS_DISTRO}/lib/python3.14/site-packages",
+            "$SNAP/usr/lib/python3/dist-packages",
+            "${PYTHONPATH}",
+        ]
+        return {
+            "command-chain": ["snap/command-chain/ros2-launch"],
+            "environment": {
+                "ROS_VERSION": self.ROS_VERSION,
+                "ROS_DISTRO": self.ROS_DISTRO,
+                "PYTHONPATH": ":".join(python_paths),
+                # Various ROS 2 tools (e.g. spdlog logger) keep a cache or a log,
+                # and use $ROS_HOME to determine where to put them.
+                "ROS_HOME": "$SNAP_USER_DATA/ros",
+            },
+        }
+
+    @overrides
+    def get_part_snippet(self, *, plugin_name: str) -> dict[str, Any]:
+        return {
+            "build-environment": [
+                {"ROS_VERSION": self.ROS_VERSION},
+                {"ROS_DISTRO": self.ROS_DISTRO},
+            ]
+        }
+
+    @overrides
+    def get_parts_snippet(self) -> dict[str, Any]:
+        return {
+            f"ros2-{self.ROS_DISTRO}/ros2-launch": {
+                "source": f"{get_extensions_data_dir()}/ros2",
+                "plugin": "make",
+                "build-packages": [
+                    f"ros-{self.ROS_DISTRO}-ros-environment",
+                    f"ros-{self.ROS_DISTRO}-ros-workspace",
+                    f"ros-{self.ROS_DISTRO}-ament-index-cpp",
+                    f"ros-{self.ROS_DISTRO}-ament-index-python",
+                ],
+            }
+        }

--- a/snapcraft/extensions/ros2_lyrical.py
+++ b/snapcraft/extensions/ros2_lyrical.py
@@ -50,7 +50,7 @@ class ROS2LyricalExtension(Extension):
             "package-repositories": [
                 {
                     "type": "apt",
-                    "url": "http://packages.ros.org/ros2/ubuntu",
+                    "url": "http://packages.ros.org/ros2-testing/ubuntu",
                     "components": ["main"],
                     "formats": ["deb"],
                     "key-id": "C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654",
@@ -90,12 +90,22 @@ class ROS2LyricalExtension(Extension):
             "$SNAP/usr/lib/python3/dist-packages",
             "${PYTHONPATH}",
         ]
+        ld_library_paths = [
+            "$SNAP/usr/lib/x86_64-linux-gnu/blas",
+            "$SNAP/usr/lib/x86_64-linux-gnu/lapack",
+            "$SNAP/usr/lib/aarch64-linux-gnu/blas",
+            "$SNAP/usr/lib/aarch64-linux-gnu/lapack",
+            "$SNAP/usr/lib/arm-linux-gnueabihf/blas",
+            "$SNAP/usr/lib/arm-linux-gnueabihf/lapack",
+            "${LD_LIBRARY_PATH}",
+        ]
         return {
             "command-chain": ["snap/command-chain/ros2-launch"],
             "environment": {
                 "ROS_VERSION": self.ROS_VERSION,
                 "ROS_DISTRO": self.ROS_DISTRO,
                 "PYTHONPATH": ":".join(python_paths),
+                "LD_LIBRARY_PATH": ":".join(ld_library_paths),
                 # Various ROS 2 tools (e.g. spdlog logger) keep a cache or a log,
                 # and use $ROS_HOME to determine where to put them.
                 "ROS_HOME": "$SNAP_USER_DATA/ros",
@@ -117,11 +127,20 @@ class ROS2LyricalExtension(Extension):
             f"ros2-{self.ROS_DISTRO}/ros2-launch": {
                 "source": f"{get_extensions_data_dir()}/ros2",
                 "plugin": "make",
+                "make-parameters": ["DESTDIR=${CRAFT_PART_INSTALL}"],
                 "build-packages": [
                     f"ros-{self.ROS_DISTRO}-ros-environment",
                     f"ros-{self.ROS_DISTRO}-ros-workspace",
                     f"ros-{self.ROS_DISTRO}-ament-index-cpp",
                     f"ros-{self.ROS_DISTRO}-ament-index-python",
+                ],
+                "stage-packages": [
+                    "libpython3.14-minimal",
+                    "libpython3.14-stdlib",
+                    "python3-minimal",  # for the "python3" symlink
+                    "python3.14-minimal",
+                    "python3.14-venv",
+                    "python3-yaml",
                 ],
             }
         }

--- a/snapcraft/extensions/ros2_lyrical.py
+++ b/snapcraft/extensions/ros2_lyrical.py
@@ -50,7 +50,7 @@ class ROS2LyricalExtension(Extension):
             "package-repositories": [
                 {
                     "type": "apt",
-                    "url": "http://packages.ros.org/ros2-testing/ubuntu",
+                    "url": "http://packages.ros.org/ros2/ubuntu",
                     "components": ["main"],
                     "formats": ["deb"],
                     "key-id": "C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654",

--- a/snapcraft/extensions/ros2_lyrical.py
+++ b/snapcraft/extensions/ros2_lyrical.py
@@ -18,7 +18,7 @@
 
 from typing import Any, Final
 
-from overrides import overrides
+from typing_extensions import override
 
 from .extension import Extension, get_extensions_data_dir
 
@@ -30,21 +30,21 @@ class ROS2LyricalExtension(Extension):
     ROS_DISTRO: Final[str] = "lyrical"
 
     @staticmethod
-    @overrides
+    @override
     def get_supported_bases() -> tuple[str, ...]:
         return ("core26",)
 
     @staticmethod
-    @overrides
+    @override
     def get_supported_confinement() -> tuple[str, ...]:
         return ("strict", "devmode")
 
     @staticmethod
-    @overrides
+    @override
     def is_experimental(base: str | None) -> bool:
         return True
 
-    @overrides
+    @override
     def get_root_snippet(self) -> dict[str, Any]:
         return {
             "package-repositories": [
@@ -83,7 +83,7 @@ class ROS2LyricalExtension(Extension):
             },
         }
 
-    @overrides
+    @override
     def get_app_snippet(self, *, app_name: str) -> dict[str, Any]:
         python_paths = [
             f"$SNAP/opt/ros/{self.ROS_DISTRO}/lib/python3.14/site-packages",
@@ -112,7 +112,7 @@ class ROS2LyricalExtension(Extension):
             },
         }
 
-    @overrides
+    @override
     def get_part_snippet(self, *, plugin_name: str) -> dict[str, Any]:
         return {
             "build-environment": [
@@ -121,7 +121,7 @@ class ROS2LyricalExtension(Extension):
             ]
         }
 
-    @overrides
+    @override
     def get_parts_snippet(self) -> dict[str, Any]:
         return {
             f"ros2-{self.ROS_DISTRO}/ros2-launch": {

--- a/snapcraft/extensions/ros2_lyrical.py
+++ b/snapcraft/extensions/ros2_lyrical.py
@@ -127,7 +127,6 @@ class ROS2LyricalExtension(Extension):
             f"ros2-{self.ROS_DISTRO}/ros2-launch": {
                 "source": f"{get_extensions_data_dir()}/ros2",
                 "plugin": "make",
-                "make-parameters": ["DESTDIR=${CRAFT_PART_INSTALL}"],
                 "build-packages": [
                     f"ros-{self.ROS_DISTRO}-ros-environment",
                     f"ros-{self.ROS_DISTRO}-ros-workspace",

--- a/snapcraft/extensions/ros2_lyrical_desktop.py
+++ b/snapcraft/extensions/ros2_lyrical_desktop.py
@@ -1,0 +1,38 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Extension to the Colcon plugin for ROS 2 Lyrical using content sharing."""
+
+import functools
+
+from overrides import overrides
+
+from ._ros2_lyrical_meta import ROS2LyricalMetaBase, ROS2LyricalSnaps
+
+
+class ROS2LyricalDesktopExtension(ROS2LyricalMetaBase):
+    """Drives ROS 2 build and runtime environment for snap using content-sharing."""
+
+    @functools.cached_property
+    @overrides
+    def ros2_lyrical_snaps(  # type: ignore[reportIncompatibleMethodOverride]
+        self,
+    ) -> ROS2LyricalSnaps:
+        return ROS2LyricalSnaps(
+            sdk="ros-lyrical-desktop-dev",
+            content="ros-lyrical-desktop",
+            variant="desktop",
+        )

--- a/snapcraft/extensions/ros2_lyrical_desktop.py
+++ b/snapcraft/extensions/ros2_lyrical_desktop.py
@@ -16,9 +16,7 @@
 
 """Extension to the Colcon plugin for ROS 2 Lyrical using content sharing."""
 
-import functools
-
-from overrides import overrides
+from typing_extensions import override
 
 from ._ros2_lyrical_meta import ROS2LyricalMetaBase, ROS2LyricalSnaps
 
@@ -26,9 +24,9 @@ from ._ros2_lyrical_meta import ROS2LyricalMetaBase, ROS2LyricalSnaps
 class ROS2LyricalDesktopExtension(ROS2LyricalMetaBase):
     """Drives ROS 2 build and runtime environment for snap using content-sharing."""
 
-    @functools.cached_property
-    @overrides
-    def ros2_lyrical_snaps(  # type: ignore[reportIncompatibleMethodOverride]
+    @property
+    @override
+    def ros2_lyrical_snaps(
         self,
     ) -> ROS2LyricalSnaps:
         return ROS2LyricalSnaps(

--- a/snapcraft/extensions/ros2_lyrical_ros_base.py
+++ b/snapcraft/extensions/ros2_lyrical_ros_base.py
@@ -1,0 +1,38 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Extension to the Colcon plugin for ROS 2 Lyrical using content sharing."""
+
+import functools
+
+from overrides import overrides
+
+from ._ros2_lyrical_meta import ROS2LyricalMetaBase, ROS2LyricalSnaps
+
+
+class ROS2LyricalRosBaseExtension(ROS2LyricalMetaBase):
+    """Drives ROS 2 build and runtime environment for snap using content-sharing."""
+
+    @functools.cached_property
+    @overrides
+    def ros2_lyrical_snaps(  # type: ignore[reportIncompatibleMethodOverride]
+        self,
+    ) -> ROS2LyricalSnaps:
+        return ROS2LyricalSnaps(
+            sdk="ros-lyrical-ros-base-dev",
+            content="ros-lyrical-ros-base",
+            variant="ros-base",
+        )

--- a/snapcraft/extensions/ros2_lyrical_ros_base.py
+++ b/snapcraft/extensions/ros2_lyrical_ros_base.py
@@ -16,9 +16,7 @@
 
 """Extension to the Colcon plugin for ROS 2 Lyrical using content sharing."""
 
-import functools
-
-from overrides import overrides
+from typing_extensions import override
 
 from ._ros2_lyrical_meta import ROS2LyricalMetaBase, ROS2LyricalSnaps
 
@@ -26,9 +24,9 @@ from ._ros2_lyrical_meta import ROS2LyricalMetaBase, ROS2LyricalSnaps
 class ROS2LyricalRosBaseExtension(ROS2LyricalMetaBase):
     """Drives ROS 2 build and runtime environment for snap using content-sharing."""
 
-    @functools.cached_property
-    @overrides
-    def ros2_lyrical_snaps(  # type: ignore[reportIncompatibleMethodOverride]
+    @property
+    @override
+    def ros2_lyrical_snaps(
         self,
     ) -> ROS2LyricalSnaps:
         return ROS2LyricalSnaps(

--- a/snapcraft/extensions/ros2_lyrical_ros_core.py
+++ b/snapcraft/extensions/ros2_lyrical_ros_core.py
@@ -1,0 +1,38 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2026 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Extension to the Colcon plugin for ROS 2 Lyrical using content sharing."""
+
+import functools
+
+from overrides import overrides
+
+from ._ros2_lyrical_meta import ROS2LyricalMetaBase, ROS2LyricalSnaps
+
+
+class ROS2LyricalRosCoreExtension(ROS2LyricalMetaBase):
+    """Drives ROS 2 build and runtime environment for snap using content-sharing."""
+
+    @functools.cached_property
+    @overrides
+    def ros2_lyrical_snaps(  # type: ignore[reportIncompatibleMethodOverride]
+        self,
+    ) -> ROS2LyricalSnaps:
+        return ROS2LyricalSnaps(
+            sdk="ros-lyrical-ros-core-dev",
+            content="ros-lyrical-ros-core",
+            variant="ros-core",
+        )

--- a/snapcraft/extensions/ros2_lyrical_ros_core.py
+++ b/snapcraft/extensions/ros2_lyrical_ros_core.py
@@ -16,9 +16,7 @@
 
 """Extension to the Colcon plugin for ROS 2 Lyrical using content sharing."""
 
-import functools
-
-from overrides import overrides
+from typing_extensions import override
 
 from ._ros2_lyrical_meta import ROS2LyricalMetaBase, ROS2LyricalSnaps
 
@@ -26,9 +24,9 @@ from ._ros2_lyrical_meta import ROS2LyricalMetaBase, ROS2LyricalSnaps
 class ROS2LyricalRosCoreExtension(ROS2LyricalMetaBase):
     """Drives ROS 2 build and runtime environment for snap using content-sharing."""
 
-    @functools.cached_property
-    @overrides
-    def ros2_lyrical_snaps(  # type: ignore[reportIncompatibleMethodOverride]
+    @property
+    @override
+    def ros2_lyrical_snaps(
         self,
     ) -> ROS2LyricalSnaps:
         return ROS2LyricalSnaps(

--- a/snapcraft/parts/plugins/_ros.py
+++ b/snapcraft/parts/plugins/_ros.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -85,7 +85,7 @@ def _parse_rosdep_resolve_dependencies(
 class RosPlugin(plugins.Plugin):
     """Base class for ROS-related plugins. Not intended for use by end users."""
 
-    _MAP_CORE_ROSDISTRO = {"core22": "humble", "core24": "jazzy"}
+    _MAP_CORE_ROSDISTRO = {"core22": "humble", "core24": "jazzy", "core26": "lyrical"}
 
     @override
     def get_build_snaps(self) -> set[str]:

--- a/snapcraft/parts/plugins/_ros.py
+++ b/snapcraft/parts/plugins/_ros.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2026 Canonical Ltd.
+# Copyright 2022 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/tests/spread/extensions/ros2-lyrical-hello/task.yaml
+++ b/tests/spread/extensions/ros2-lyrical-hello/task.yaml
@@ -1,0 +1,68 @@
+summary: >-
+  Build, clean, build, modify and rebuild, and run hello
+  with different plugin configurations
+
+priority: 100
+
+systems:
+  - ubuntu-26.04
+  - ubuntu-26.04-64
+  - ubuntu-26.04-amd64
+  - ubuntu-26.04-arm64
+
+environment:
+
+  SNAP_DIR: ../snaps/ros2-lyrical-hello
+  SNAP: ros2-lyrical-hello
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "${SNAP_DIR}/snap/snapcraft.yaml"
+
+  #shellcheck source=tests/spread/tools/package-utils.sh
+  . "$TOOLS_DIR/package-utils.sh"
+  create_dpkg_restore_point
+
+restore: |
+  cd "${SNAP_DIR}"
+  snapcraft clean
+  rm -f ./*.snap
+
+  # Undo changes to hello
+  [ -f src/hello.cpp ] && git checkout src/hello.cpp
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+  #shellcheck source=tests/spread/tools/package-utils.sh
+  . "$TOOLS_DIR/package-utils.sh"
+  dpkg_restore_point
+
+execute: |
+  cd "${SNAP_DIR}"
+
+  # Make sure expand-extensions works
+  snapcraft expand-extensions
+
+  # Build what we have and verify the snap runs as expected.
+  snapcraft
+  snap install "${SNAP}"_1.0_*.snap --dangerous
+
+  # Clean the hello part, then build and run again.
+  snapcraft clean hello
+  snapcraft
+  snap install "${SNAP}"_1.0_*.snap --dangerous
+
+  # Make sure that what we built runs with the changes applied.
+  if [ -f src/hello.cpp ]; then
+    modified_file=src/hello.cpp
+  else
+    FATAL "Cannot setup ${SNAP} for rebuilding"
+  fi
+
+  sed -i "${modified_file}" -e 's/hello world/hello rebuilt world/'
+
+  snapcraft
+  snap install "${SNAP}"_1.0_*.snap --dangerous

--- a/tests/spread/extensions/ros2-lyrical-hello/task.yaml
+++ b/tests/spread/extensions/ros2-lyrical-hello/task.yaml
@@ -47,12 +47,12 @@ execute: |
   snapcraft expand-extensions
 
   # Build what we have and verify the snap runs as expected.
-  snapcraft
+  snapcraft pack
   snap install "${SNAP}"_1.0_*.snap --dangerous
 
   # Clean the hello part, then build and run again.
   snapcraft clean hello
-  snapcraft
+  snapcraft pack
   snap install "${SNAP}"_1.0_*.snap --dangerous
 
   # Make sure that what we built runs with the changes applied.
@@ -64,5 +64,5 @@ execute: |
 
   sed -i "${modified_file}" -e 's/hello world/hello rebuilt world/'
 
-  snapcraft
+  snapcraft pack
   snap install "${SNAP}"_1.0_*.snap --dangerous

--- a/tests/spread/extensions/ros2-lyrical-meta-hello/task.yaml
+++ b/tests/spread/extensions/ros2-lyrical-meta-hello/task.yaml
@@ -3,42 +3,47 @@ summary: Build and run a basic ROS 2 snap using meta-ros extension
 kill-timeout: 180m
 
 environment:
+
   SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "1"
 
-  SNAP: colcon-talker-listener
-  SNAP_DIR: "../../plugins/craft-parts/$SNAP/$SNAP"
+  SNAP: ros2-lyrical-hello
+  SNAP_DIR: "../snaps/${SNAP}"
 
-  META_SNAP/colcon_jazzy_ros_core: ros-jazzy-ros-core
-  EXTENSION/colcon_jazzy_ros_core: ros2-jazzy-ros-core
-  INTERFACE/colcon_jazzy_ros_core: ros-jazzy-ros-core
+  META_SNAP/colcon_lyrical_ros_core: ros-lyrical-ros-core
+  EXTENSION/colcon_lyrical_ros_core: ros2-lyrical-ros-core
+  INTERFACE/colcon_lyrical_ros_core: ros-lyrical-ros-core
 
-  META_SNAP/colcon_jazzy_ros_base: ros-jazzy-ros-base
-  EXTENSION/colcon_jazzy_ros_base: ros2-jazzy-ros-base
-  INTERFACE/colcon_jazzy_ros_base: ros-jazzy-ros-base
+  META_SNAP/colcon_lyrical_ros_base: ros-lyrical-ros-base
+  EXTENSION/colcon_lyrical_ros_base: ros2-lyrical-ros-base
+  INTERFACE/colcon_lyrical_ros_base: ros-lyrical-ros-base
 
-  META_SNAP/colcon_jazzy_desktop: ros-jazzy-desktop
-  EXTENSION/colcon_jazzy_desktop: ros2-jazzy-desktop
-  INTERFACE/colcon_jazzy_desktop: ros-jazzy-desktop
+  META_SNAP/colcon_lyrical_desktop: ros-lyrical-desktop
+  EXTENSION/colcon_lyrical_desktop: ros2-lyrical-desktop
+  INTERFACE/colcon_lyrical_desktop: ros-lyrical-desktop
 
 # The content snap required for the test to succeed is only
 # available on a subset of all the architectures this testbed
 # can run on.
 systems:
-  - ubuntu-24.04
-  - ubuntu-24.04-64
-  - ubuntu-24.04-amd64
-  - ubuntu-24.04-arm64
+  - ubuntu-26.04
+  - ubuntu-26.04-64
+  - ubuntu-26.04-amd64
+  - ubuntu-26.04-arm64
 
 prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   set_base "$SNAP_DIR/snap/snapcraft.yaml"
 
-  # Overwrite the core version
-  sed -i "s|core22|core24|" "$SNAP_DIR/snap/snapcraft.yaml"
-
   # Overwrite the extension to test them all out of a single snap
-  sed -i "s|ros2-jazzy|${EXTENSION}|" "$SNAP_DIR/snap/snapcraft.yaml"
+  sed -i "s|\[ros2-lyrical\]|\[${EXTENSION}\]|" "$SNAP_DIR/snap/snapcraft.yaml"
+
+  # The snap stages ros2run which will be available through content-sharing
+  sed -i "\|stage-packages|d" "$SNAP_DIR/snap/snapcraft.yaml"
+
+  # The actual ros2 bin is provided by the content-sharing snap.
+  # Use the wrapper instead.
+  sed -i "s|opt/ros/lyrical/bin/ros2|ros2|" "$SNAP_DIR/snap/snapcraft.yaml"
 
   #shellcheck source=tests/spread/tools/package-utils.sh
   . "$TOOLS_DIR/package-utils.sh"
@@ -63,20 +68,16 @@ execute: |
   cd "$SNAP_DIR"
 
   # Build what we have and verify the snap runs as expected.
-  snapcraft pack
+  snapcraft
   snap install "${SNAP}"_1.0_*.snap --dangerous
 
   # Check that the snap size is fairly small
   # The non-content sharing snap is ~90M
   SNAP_SIZE=$(find . -maxdepth 1 -mindepth 1 -name '*_1.0_*.snap' -exec ls -s {} + | cut -d " " -f1)
-  [ "800" -gt "$SNAP_SIZE" ]
+  [ "200" -gt "$SNAP_SIZE" ]
 
   # The default providing snap is installed automatically
   # snap install "${META_SNAP}"
 
   snap connect "${SNAP}:${INTERFACE}" "${META_SNAP}:${INTERFACE}"
-
-  # Run the ROS system. By default this will never exit, but the snap supports
-  # an `exit_after_receive` parameter that, if true, will cause the system to
-  # shutdown after the listener has successfully received a message.
-  "$SNAP" exit_after_receive:=true | MATCH "I heard: 'Hello, world! 0'"
+  [ "$($SNAP)" = "hello world" ]

--- a/tests/spread/extensions/ros2-lyrical-meta-hello/task.yaml
+++ b/tests/spread/extensions/ros2-lyrical-meta-hello/task.yaml
@@ -68,7 +68,7 @@ execute: |
   cd "$SNAP_DIR"
 
   # Build what we have and verify the snap runs as expected.
-  snapcraft
+  snapcraft pack
   snap install "${SNAP}"_1.0_*.snap --dangerous
 
   # Check that the snap size is fairly small

--- a/tests/spread/extensions/ros2-lyrical-meta-talker-listener/task.yaml
+++ b/tests/spread/extensions/ros2-lyrical-meta-talker-listener/task.yaml
@@ -63,7 +63,7 @@ execute: |
   cd "$SNAP_DIR"
 
   # Build what we have and verify the snap runs as expected.
-  snapcraft
+  snapcraft pack
   snap install "${SNAP}"_1.0_*.snap --dangerous
 
   # Check that the snap size is fairly small

--- a/tests/spread/extensions/ros2-lyrical-meta-talker-listener/task.yaml
+++ b/tests/spread/extensions/ros2-lyrical-meta-talker-listener/task.yaml
@@ -8,26 +8,26 @@ environment:
   SNAP: colcon-talker-listener
   SNAP_DIR: "../../plugins/craft-parts/$SNAP/$SNAP"
 
-  META_SNAP/colcon_jazzy_ros_core: ros-jazzy-ros-core
-  EXTENSION/colcon_jazzy_ros_core: ros2-jazzy-ros-core
-  INTERFACE/colcon_jazzy_ros_core: ros-jazzy-ros-core
+  META_SNAP/colcon_lyrical_ros_core: ros-lyrical-ros-core
+  EXTENSION/colcon_lyrical_ros_core: ros2-lyrical-ros-core
+  INTERFACE/colcon_lyrical_ros_core: ros-lyrical-ros-core
 
-  META_SNAP/colcon_jazzy_ros_base: ros-jazzy-ros-base
-  EXTENSION/colcon_jazzy_ros_base: ros2-jazzy-ros-base
-  INTERFACE/colcon_jazzy_ros_base: ros-jazzy-ros-base
+  META_SNAP/colcon_lyrical_ros_base: ros-lyrical-ros-base
+  EXTENSION/colcon_lyrical_ros_base: ros2-lyrical-ros-base
+  INTERFACE/colcon_lyrical_ros_base: ros-lyrical-ros-base
 
-  META_SNAP/colcon_jazzy_desktop: ros-jazzy-desktop
-  EXTENSION/colcon_jazzy_desktop: ros2-jazzy-desktop
-  INTERFACE/colcon_jazzy_desktop: ros-jazzy-desktop
+  META_SNAP/colcon_lyrical_desktop: ros-lyrical-desktop
+  EXTENSION/colcon_lyrical_desktop: ros2-lyrical-desktop
+  INTERFACE/colcon_lyrical_desktop: ros-lyrical-desktop
 
 # The content snap required for the test to succeed is only
 # available on a subset of all the architectures this testbed
 # can run on.
 systems:
-  - ubuntu-24.04
-  - ubuntu-24.04-64
-  - ubuntu-24.04-amd64
-  - ubuntu-24.04-arm64
+  - ubuntu-26.04
+  - ubuntu-26.04-64
+  - ubuntu-26.04-amd64
+  - ubuntu-26.04-arm64
 
 prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
@@ -35,10 +35,10 @@ prepare: |
   set_base "$SNAP_DIR/snap/snapcraft.yaml"
 
   # Overwrite the core version
-  sed -i "s|core22|core24|" "$SNAP_DIR/snap/snapcraft.yaml"
+  sed -i "s|core22|core26|" "$SNAP_DIR/snap/snapcraft.yaml"
 
   # Overwrite the extension to test them all out of a single snap
-  sed -i "s|ros2-jazzy|${EXTENSION}|" "$SNAP_DIR/snap/snapcraft.yaml"
+  sed -i "s|ros2-humble|${EXTENSION}|" "$SNAP_DIR/snap/snapcraft.yaml"
 
   #shellcheck source=tests/spread/tools/package-utils.sh
   . "$TOOLS_DIR/package-utils.sh"
@@ -63,7 +63,7 @@ execute: |
   cd "$SNAP_DIR"
 
   # Build what we have and verify the snap runs as expected.
-  snapcraft pack
+  snapcraft
   snap install "${SNAP}"_1.0_*.snap --dangerous
 
   # Check that the snap size is fairly small

--- a/tests/spread/extensions/snaps/ros2-lyrical-hello/CMakeLists.txt
+++ b/tests/spread/extensions/snaps/ros2-lyrical-hello/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.14.4)
+project(colcon_ros2_rlcpp_hello)
+
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(std_msgs REQUIRED)
+
+# This package installs libraries without exporting them.
+# Export the library path to ensure that the installed libraries are available.
+if(NOT WIN32)
+  ament_environment_hooks(
+    "${ament_cmake_package_templates_ENVIRONMENT_HOOK_LIBRARY_PATH}"
+    )
+endif()
+
+add_executable(colcon_ros2_rlcpp_hello src/hello.cpp)
+target_link_libraries(colcon_ros2_rlcpp_hello)
+ament_target_dependencies(colcon_ros2_rlcpp_hello rclcpp class_loader)
+
+install(TARGETS
+  colcon_ros2_rlcpp_hello
+  DESTINATION lib/${PROJECT_NAME})
+
+ament_package()

--- a/tests/spread/extensions/snaps/ros2-lyrical-hello/package.xml
+++ b/tests/spread/extensions/snaps/ros2-lyrical-hello/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>colcon_ros2_rlcpp_hello</name>
+  <version>0.0.1</version>
+  <description>snapcraft test for rlcpp</description>
+  <maintainer email="me@example.com">me</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend condition="$ROS_VERSION == 2">rclcpp</build_depend>
+  <build_depend>rclcpp_components</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend condition="$ROS_VERSION == 1">fake_package_that_does_not_exists</build_depend>
+
+  <exec_depend condition="$ROS_VERSION == 2">rclcpp</exec_depend>
+  <exec_depend>rclcpp_components</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/tests/spread/extensions/snaps/ros2-lyrical-hello/snap/snapcraft.yaml
+++ b/tests/spread/extensions/snaps/ros2-lyrical-hello/snap/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: ros2-lyrical-hello
+version: "1.0"
+summary: hello world
+description: |
+  A ROS 2 rclcpp-based workspace.
+
+base: core26
+build-base: devel
+grade: devel
+confinement: strict
+
+apps:
+  ros2-lyrical-hello:
+    command: opt/ros/lyrical/bin/ros2 run colcon_ros2_rlcpp_hello colcon_ros2_rlcpp_hello
+    plugs: [network, network-bind]
+    extensions: [ros2-lyrical]
+
+parts:
+  hello:
+    plugin: colcon
+    source: .
+    build-packages: [g++, make, vim]
+    stage-packages: [ros-lyrical-ros2run]

--- a/tests/spread/extensions/snaps/ros2-lyrical-hello/snap/snapcraft.yaml
+++ b/tests/spread/extensions/snaps/ros2-lyrical-hello/snap/snapcraft.yaml
@@ -5,7 +5,6 @@ description: |
   A ROS 2 rclcpp-based workspace.
 
 base: core26
-build-base: devel
 grade: devel
 confinement: strict
 

--- a/tests/spread/extensions/snaps/ros2-lyrical-hello/src/hello.cpp
+++ b/tests/spread/extensions/snaps/ros2-lyrical-hello/src/hello.cpp
@@ -1,0 +1,28 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include "rclcpp/rclcpp.hpp"
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::executors::SingleThreadedExecutor exec;
+  rclcpp::NodeOptions options;
+
+  printf("hello world");
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/tests/spread/extensions/snaps/ros2-lyrical-hello/src/hello.cpp
+++ b/tests/spread/extensions/snaps/ros2-lyrical-hello/src/hello.cpp
@@ -1,4 +1,4 @@
-// Copyright 2026 Open Source Robotics Foundation, Inc.
+// Copyright 2016 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/unit/commands/test_list_extensions.py
+++ b/tests/unit/commands/test_list_extensions.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2026 Canonical Ltd.
+# Copyright 2022,2024 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/tests/unit/commands/test_list_extensions.py
+++ b/tests/unit/commands/test_list_extensions.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022,2024 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -33,26 +33,30 @@ def test_command(emitter, fake_app_config):
     emitter.assert_message(
         dedent(
             """\
-        Extension name        Supported bases
-        --------------------  ----------------------
-        dotnet10              core24
-        dotnet8               core24
-        dotnet9               core24
-        env-injector          core24
-        fake-extension        core22, core24, core26
-        gnome                 core22, core24
-        gpu                   core22, core24, core26
-        kde-neon              core22, core24
-        kde-neon-6            core22, core24
-        kde-neon-qt6          core22, core24
-        ros2-humble           core22
-        ros2-humble-desktop   core22
-        ros2-humble-ros-base  core22
-        ros2-humble-ros-core  core22
-        ros2-jazzy            core24
-        ros2-jazzy-desktop    core24
-        ros2-jazzy-ros-base   core24
-        ros2-jazzy-ros-core   core24"""
+        Extension name         Supported bases
+        ---------------------  ----------------------
+        dotnet10               core24
+        dotnet8                core24
+        dotnet9                core24
+        env-injector           core24
+        fake-extension         core22, core24, core26
+        gnome                  core22, core24
+        gpu                    core22, core24, core26
+        kde-neon               core22, core24
+        kde-neon-6             core22, core24
+        kde-neon-qt6           core22, core24
+        ros2-humble            core22
+        ros2-humble-desktop    core22
+        ros2-humble-ros-base   core22
+        ros2-humble-ros-core   core22
+        ros2-jazzy             core24
+        ros2-jazzy-desktop     core24
+        ros2-jazzy-ros-base    core24
+        ros2-jazzy-ros-core    core24
+        ros2-lyrical           core26
+        ros2-lyrical-desktop   core26
+        ros2-lyrical-ros-base  core26
+        ros2-lyrical-ros-core  core26"""
         )
     )
 

--- a/tests/unit/extensions/test_registry.py
+++ b/tests/unit/extensions/test_registry.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -38,6 +38,10 @@ def test_get_extension_names():
         "ros2-jazzy-ros-core",
         "ros2-jazzy-ros-base",
         "ros2-jazzy-desktop",
+        "ros2-lyrical",
+        "ros2-lyrical-ros-core",
+        "ros2-lyrical-ros-base",
+        "ros2-lyrical-desktop",
         "kde-neon",
         "kde-neon-6",
         "kde-neon-qt6",

--- a/tests/unit/extensions/test_registry.py
+++ b/tests/unit/extensions/test_registry.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2026 Canonical Ltd.
+# Copyright 2022 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/tests/unit/parts/extensions/test_ros2_lyrical.py
+++ b/tests/unit/parts/extensions/test_ros2_lyrical.py
@@ -1,0 +1,146 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2026 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+import snapcraft.extensions.registry as reg
+from snapcraft import errors
+from snapcraft.extensions.extension import get_extensions_data_dir
+from snapcraft.extensions.ros2_lyrical import ROS2LyricalExtension
+
+_EXTENSION_NAME = "ros2-lyrical"
+
+
+@pytest.fixture
+def setup_method_fixture():
+    def _setup_method_fixture(yaml_data=None, arch=None, target_arch=None):
+        if yaml_data is None:
+            yaml_data = {}
+        if arch is None:
+            arch = "amd64"
+        if target_arch is None:
+            target_arch = "amd64"
+
+        return ROS2LyricalExtension(
+            yaml_data=yaml_data, arch=arch, target_arch=target_arch
+        )
+
+    yield _setup_method_fixture
+
+
+class TestExtensionROS2LyricalExtension:
+    """ROS 2 Lyrical extension tests."""
+
+    def test_is_registered(self):
+        assert _EXTENSION_NAME in reg.get_extension_names()
+
+        try:
+            reg.get_extension_class(_EXTENSION_NAME)
+        except errors.ExtensionError as exc:
+            raise AssertionError(f"Couldn't get extension '{_EXTENSION_NAME}': {exc}")
+
+    def test_ros_version(self, setup_method_fixture):
+        extension = setup_method_fixture()
+        assert extension.ROS_VERSION == "2"
+
+    def test_is_experimental(self, setup_method_fixture):
+        extension = setup_method_fixture()
+        assert extension.is_experimental(None)
+
+    def test_get_supported_bases(self, setup_method_fixture):
+        extension = setup_method_fixture()
+        assert extension.get_supported_bases() == ("core26",)
+
+    def test_get_supported_confinement(self, setup_method_fixture):
+        extension = setup_method_fixture()
+        assert extension.get_supported_confinement() == ("strict", "devmode")
+
+    def test_get_root_snippet(self, setup_method_fixture):
+        extension = setup_method_fixture()
+        assert extension.get_root_snippet() == {
+            "package-repositories": [
+                {
+                    "type": "apt",
+                    "url": "http://packages.ros.org/ros2/ubuntu",
+                    "components": ["main"],
+                    "formats": ["deb"],
+                    "key-id": "C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654",
+                    "key-server": "keyserver.ubuntu.com",
+                    "suites": ["resolute"],
+                }
+            ],
+            "lint": {
+                "ignore": [
+                    {
+                        "unused-library": [
+                            "opt/ros/*",
+                            "lib/*/libcrypt.so*",
+                            "lib/*/libexpat.so*",
+                            "lib/*/libtirpc.so*",
+                            "lib/*/libz.so*",
+                            "usr/lib/*libatomic.so*",
+                            "usr/lib/*libconsole_bridge.so*",
+                            "usr/lib/*libfmt.so*",
+                            "usr/lib/*libicui18n.so*",
+                            "usr/lib/*libicuio.so*",
+                            "usr/lib/*libicutest.so*",
+                            "usr/lib/*libicutu.so*",
+                            "usr/lib/*libpython3.14.so*",
+                            "usr/lib/*libspdlog.so*",
+                            "usr/lib/*libtinyxml2.so*",
+                        ]
+                    }
+                ]
+            },
+        }
+
+    def test_get_app_snippet(self, setup_method_fixture):
+        python_paths = [
+            "$SNAP/opt/ros/lyrical/lib/python3.14/site-packages",
+            "$SNAP/usr/lib/python3/dist-packages",
+            "${PYTHONPATH}",
+        ]
+        extension = setup_method_fixture()
+        assert extension.get_app_snippet(app_name="test-app") == {
+            "command-chain": ["snap/command-chain/ros2-launch"],
+            "environment": {
+                "ROS_VERSION": "2",
+                "ROS_DISTRO": "lyrical",
+                "PYTHONPATH": ":".join(python_paths),
+                "ROS_HOME": "$SNAP_USER_DATA/ros",
+            },
+        }
+
+    def test_get_part_snippet(self, setup_method_fixture):
+        extension = setup_method_fixture()
+        assert extension.get_part_snippet(plugin_name="colcon") == {
+            "build-environment": [{"ROS_VERSION": "2"}, {"ROS_DISTRO": "lyrical"}]
+        }
+
+    def test_get_parts_snippet(self, setup_method_fixture):
+        extension = setup_method_fixture()
+        assert extension.get_parts_snippet() == {
+            "ros2-lyrical/ros2-launch": {
+                "source": f"{get_extensions_data_dir()}/ros2",
+                "plugin": "make",
+                "build-packages": [
+                    "ros-lyrical-ros-environment",
+                    "ros-lyrical-ros-workspace",
+                    "ros-lyrical-ament-index-cpp",
+                    "ros-lyrical-ament-index-python",
+                ],
+            }
+        }

--- a/tests/unit/parts/extensions/test_ros2_lyrical.py
+++ b/tests/unit/parts/extensions/test_ros2_lyrical.py
@@ -74,7 +74,7 @@ class TestExtensionROS2LyricalExtension:
             "package-repositories": [
                 {
                     "type": "apt",
-                    "url": "http://packages.ros.org/ros2-testing/ubuntu",
+                    "url": "http://packages.ros.org/ros2/ubuntu",
                     "components": ["main"],
                     "formats": ["deb"],
                     "key-id": "C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654",

--- a/tests/unit/parts/extensions/test_ros2_lyrical.py
+++ b/tests/unit/parts/extensions/test_ros2_lyrical.py
@@ -74,7 +74,7 @@ class TestExtensionROS2LyricalExtension:
             "package-repositories": [
                 {
                     "type": "apt",
-                    "url": "http://packages.ros.org/ros2/ubuntu",
+                    "url": "http://packages.ros.org/ros2-testing/ubuntu",
                     "components": ["main"],
                     "formats": ["deb"],
                     "key-id": "C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654",
@@ -113,6 +113,15 @@ class TestExtensionROS2LyricalExtension:
             "$SNAP/usr/lib/python3/dist-packages",
             "${PYTHONPATH}",
         ]
+        ld_library_paths = [
+            "$SNAP/usr/lib/x86_64-linux-gnu/blas",
+            "$SNAP/usr/lib/x86_64-linux-gnu/lapack",
+            "$SNAP/usr/lib/aarch64-linux-gnu/blas",
+            "$SNAP/usr/lib/aarch64-linux-gnu/lapack",
+            "$SNAP/usr/lib/arm-linux-gnueabihf/blas",
+            "$SNAP/usr/lib/arm-linux-gnueabihf/lapack",
+            "${LD_LIBRARY_PATH}",
+        ]
         extension = setup_method_fixture()
         assert extension.get_app_snippet(app_name="test-app") == {
             "command-chain": ["snap/command-chain/ros2-launch"],
@@ -120,6 +129,7 @@ class TestExtensionROS2LyricalExtension:
                 "ROS_VERSION": "2",
                 "ROS_DISTRO": "lyrical",
                 "PYTHONPATH": ":".join(python_paths),
+                "LD_LIBRARY_PATH": ":".join(ld_library_paths),
                 "ROS_HOME": "$SNAP_USER_DATA/ros",
             },
         }
@@ -136,11 +146,20 @@ class TestExtensionROS2LyricalExtension:
             "ros2-lyrical/ros2-launch": {
                 "source": f"{get_extensions_data_dir()}/ros2",
                 "plugin": "make",
+                "make-parameters": ["DESTDIR=${CRAFT_PART_INSTALL}"],
                 "build-packages": [
                     "ros-lyrical-ros-environment",
                     "ros-lyrical-ros-workspace",
                     "ros-lyrical-ament-index-cpp",
                     "ros-lyrical-ament-index-python",
+                ],
+                "stage-packages": [
+                    "libpython3.14-minimal",
+                    "libpython3.14-stdlib",
+                    "python3-minimal",
+                    "python3.14-minimal",
+                    "python3.14-venv",
+                    "python3-yaml",
                 ],
             }
         }

--- a/tests/unit/parts/extensions/test_ros2_lyrical.py
+++ b/tests/unit/parts/extensions/test_ros2_lyrical.py
@@ -27,15 +27,10 @@ _EXTENSION_NAME = "ros2-lyrical"
 @pytest.fixture
 def setup_method_fixture():
     def _setup_method_fixture(yaml_data=None, arch=None, target_arch=None):
-        if yaml_data is None:
-            yaml_data = {}
-        if arch is None:
-            arch = "amd64"
-        if target_arch is None:
-            target_arch = "amd64"
-
         return ROS2LyricalExtension(
-            yaml_data=yaml_data, arch=arch, target_arch=target_arch
+            yaml_data=yaml_data or {},
+            arch=arch or "amd64",
+            target_arch=target_arch or "amd64"
         )
 
     yield _setup_method_fixture

--- a/tests/unit/parts/extensions/test_ros2_lyrical.py
+++ b/tests/unit/parts/extensions/test_ros2_lyrical.py
@@ -141,7 +141,6 @@ class TestExtensionROS2LyricalExtension:
             "ros2-lyrical/ros2-launch": {
                 "source": f"{get_extensions_data_dir()}/ros2",
                 "plugin": "make",
-                "make-parameters": ["DESTDIR=${CRAFT_PART_INSTALL}"],
                 "build-packages": [
                     "ros-lyrical-ros-environment",
                     "ros-lyrical-ros-workspace",

--- a/tests/unit/parts/extensions/test_ros2_lyrical.py
+++ b/tests/unit/parts/extensions/test_ros2_lyrical.py
@@ -30,7 +30,7 @@ def setup_method_fixture():
         return ROS2LyricalExtension(
             yaml_data=yaml_data or {},
             arch=arch or "amd64",
-            target_arch=target_arch or "amd64"
+            target_arch=target_arch or "amd64",
         )
 
     yield _setup_method_fixture

--- a/tests/unit/parts/extensions/test_ros2_lyrical_meta.py
+++ b/tests/unit/parts/extensions/test_ros2_lyrical_meta.py
@@ -1,0 +1,191 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright (C) 2026 Canonical Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from snapcraft import errors
+from snapcraft.extensions import registry
+from snapcraft.extensions.extension import get_extensions_data_dir
+from snapcraft.extensions.ros2_lyrical_desktop import ROS2LyricalDesktopExtension
+from snapcraft.extensions.ros2_lyrical_ros_base import ROS2LyricalRosBaseExtension
+from snapcraft.extensions.ros2_lyrical_ros_core import ROS2LyricalRosCoreExtension
+
+
+def setup_method_fixture(extension, yaml_data=None, arch=None, target_arch=None):
+    return extension(yaml_data=yaml_data, arch=arch, target_arch=target_arch)
+
+
+class TestExtensionROS2LyricalMetaExtensions:
+    """ROS 2 Lyrical meta extensions tests."""
+
+    fixture_variables = "extension_name,extension_class,meta,meta_dev"
+    fixture_values = [
+        (
+            "ros2-lyrical-desktop",
+            ROS2LyricalDesktopExtension,
+            "ros-lyrical-desktop",
+            "ros-lyrical-desktop-dev",
+        ),
+        (
+            "ros2-lyrical-ros-base",
+            ROS2LyricalRosBaseExtension,
+            "ros-lyrical-ros-base",
+            "ros-lyrical-ros-base-dev",
+        ),
+        (
+            "ros2-lyrical-ros-core",
+            ROS2LyricalRosCoreExtension,
+            "ros-lyrical-ros-core",
+            "ros-lyrical-ros-core-dev",
+        ),
+    ]
+
+    @pytest.mark.parametrize(fixture_variables, fixture_values)
+    def test_is_registered(self, extension_name, extension_class, meta, meta_dev):
+        assert extension_name in registry.get_extension_names()
+
+        try:
+            registry.get_extension_class(extension_name)
+        except errors.ExtensionError as exc:
+            raise AssertionError(f"Couldn't get extension '{extension_name}': {exc}")
+
+    @pytest.mark.parametrize(fixture_variables, fixture_values)
+    def test_experimental(self, extension_name, extension_class, meta, meta_dev):
+        extension = setup_method_fixture(extension_class)
+        assert extension.is_experimental(None)
+
+    @pytest.mark.parametrize(fixture_variables, fixture_values)
+    def test_ros_version(self, extension_name, extension_class, meta, meta_dev):
+        extension = setup_method_fixture(extension_class)
+        assert extension.ROS_VERSION == "2"
+
+    @pytest.mark.parametrize(fixture_variables, fixture_values)
+    def test_get_supported_bases(self, extension_name, extension_class, meta, meta_dev):
+        extension = setup_method_fixture(extension_class)
+        assert extension.get_supported_bases() == ("core26",)
+
+    @pytest.mark.parametrize(fixture_variables, fixture_values)
+    def test_get_supported_confinement(
+        self, extension_name, extension_class, meta, meta_dev
+    ):
+        extension = setup_method_fixture(extension_class)
+        assert extension.get_supported_confinement() == ("strict", "devmode")
+
+    @pytest.mark.parametrize(fixture_variables, fixture_values)
+    def test_get_root_snippet(self, extension_name, extension_class, meta, meta_dev):
+        extension = setup_method_fixture(extension_class)
+        assert extension.get_root_snippet() == {
+            "package-repositories": [
+                {
+                    "type": "apt",
+                    "url": "http://packages.ros.org/ros2/ubuntu",
+                    "components": ["main"],
+                    "formats": ["deb"],
+                    "key-id": "C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654",
+                    "key-server": "keyserver.ubuntu.com",
+                    "suites": ["resolute"],
+                }
+            ],
+            "lint": {
+                "ignore": [
+                    {
+                        "unused-library": [
+                            "opt/ros/*",
+                            "lib/*/libcrypt.so*",
+                            "lib/*/libexpat.so*",
+                            "lib/*/libtirpc.so*",
+                            "lib/*/libz.so*",
+                            "usr/lib/*libatomic.so*",
+                            "usr/lib/*libconsole_bridge.so*",
+                            "usr/lib/*libfmt.so*",
+                            "usr/lib/*libicui18n.so*",
+                            "usr/lib/*libicuio.so*",
+                            "usr/lib/*libicutest.so*",
+                            "usr/lib/*libicutu.so*",
+                            "usr/lib/*libpython3.14.so*",
+                            "usr/lib/*libspdlog.so*",
+                            "usr/lib/*libtinyxml2.so*",
+                        ]
+                    }
+                ]
+            },
+            "plugs": {
+                meta: {
+                    "content": meta,
+                    "default-provider": meta,
+                    "interface": "content",
+                    "target": "$SNAP/opt/ros/underlay_ws",
+                }
+            },
+        }
+
+    @pytest.mark.parametrize(fixture_variables, fixture_values)
+    def test_get_app_snippet(self, extension_name, extension_class, meta, meta_dev):
+        python_paths = [
+            "$SNAP/opt/ros/lyrical/lib/python3.14/site-packages",
+            "$SNAP/usr/lib/python3/dist-packages",
+            "${PYTHONPATH}",
+            "$SNAP/opt/ros/underlay_ws/opt/ros/lyrical/lib/python3.14/site-packages",
+            "$SNAP/opt/ros/underlay_ws/usr/lib/python3/dist-packages",
+        ]
+        extension = setup_method_fixture(extension_class)
+        assert extension.get_app_snippet(app_name="test-app") == {
+            "command-chain": ["snap/command-chain/ros2-launch"],
+            "environment": {
+                "ROS_VERSION": "2",
+                "ROS_DISTRO": "lyrical",
+                "PYTHONPATH": ":".join(python_paths),
+                "ROS_HOME": "$SNAP_USER_DATA/ros",
+            },
+        }
+
+    @pytest.mark.parametrize(fixture_variables, fixture_values)
+    def test_get_part_snippet(self, extension_name, extension_class, meta, meta_dev):
+        extension = setup_method_fixture(extension_class)
+        assert extension.get_part_snippet(plugin_name="colcon") == {
+            "build-environment": [{"ROS_VERSION": "2"}, {"ROS_DISTRO": "lyrical"}],
+            "colcon-ros-build-snaps": [meta_dev],
+            "colcon-cmake-args": [
+                f'-DCMAKE_SYSTEM_PREFIX_PATH="/snap/{meta_dev}/current/usr"'
+            ],
+        }
+
+        assert extension.get_part_snippet(plugin_name="cmake") == {
+            "build-environment": [{"ROS_VERSION": "2"}, {"ROS_DISTRO": "lyrical"}],
+        }
+
+    @pytest.mark.parametrize(fixture_variables, fixture_values)
+    def test_get_parts_snippet(self, extension_name, extension_class, meta, meta_dev):
+        extension = setup_method_fixture(extension_class)
+        assert extension.get_parts_snippet() == {
+            f"{extension_name}/ros2-launch": {
+                "source": f"{get_extensions_data_dir()}/ros2",
+                "plugin": "make",
+                "build-packages": [
+                    "ros-lyrical-ros-environment",
+                    "ros-lyrical-ros-workspace",
+                    "ros-lyrical-ament-index-cpp",
+                    "ros-lyrical-ament-index-python",
+                    "libpython3.14-dev",
+                ],
+                "stage-packages": [
+                    "ros-lyrical-ros-environment",
+                    "ros-lyrical-ros-workspace",
+                    "ros-lyrical-ament-index-cpp",
+                    "ros-lyrical-ament-index-python",
+                ],
+            }
+        }

--- a/tests/unit/parts/extensions/test_ros2_lyrical_meta.py
+++ b/tests/unit/parts/extensions/test_ros2_lyrical_meta.py
@@ -141,6 +141,21 @@ class TestExtensionROS2LyricalMetaExtensions:
             "$SNAP/opt/ros/underlay_ws/opt/ros/lyrical/lib/python3.14/site-packages",
             "$SNAP/opt/ros/underlay_ws/usr/lib/python3/dist-packages",
         ]
+        ld_library_paths = [
+            "$SNAP/usr/lib/x86_64-linux-gnu/blas",
+            "$SNAP/usr/lib/x86_64-linux-gnu/lapack",
+            "$SNAP/usr/lib/aarch64-linux-gnu/blas",
+            "$SNAP/usr/lib/aarch64-linux-gnu/lapack",
+            "$SNAP/usr/lib/arm-linux-gnueabihf/blas",
+            "$SNAP/usr/lib/arm-linux-gnueabihf/lapack",
+            "${LD_LIBRARY_PATH}",
+            "$SNAP/opt/ros/underlay_ws/usr/lib/x86_64-linux-gnu/blas",
+            "$SNAP/opt/ros/underlay_ws/usr/lib/x86_64-linux-gnu/lapack",
+            "$SNAP/opt/ros/underlay_ws/usr/lib/aarch64-linux-gnu/blas",
+            "$SNAP/opt/ros/underlay_ws/usr/lib/aarch64-linux-gnu/lapack",
+            "$SNAP/opt/ros/underlay_ws/usr/lib/arm-linux-gnueabihf/blas",
+            "$SNAP/opt/ros/underlay_ws/usr/lib/arm-linux-gnueabihf/lapack",
+        ]
         extension = setup_method_fixture(extension_class)
         assert extension.get_app_snippet(app_name="test-app") == {
             "command-chain": ["snap/command-chain/ros2-launch"],
@@ -148,6 +163,7 @@ class TestExtensionROS2LyricalMetaExtensions:
                 "ROS_VERSION": "2",
                 "ROS_DISTRO": "lyrical",
                 "PYTHONPATH": ":".join(python_paths),
+                "LD_LIBRARY_PATH": ":".join(ld_library_paths),
                 "ROS_HOME": "$SNAP_USER_DATA/ros",
             },
         }
@@ -157,7 +173,7 @@ class TestExtensionROS2LyricalMetaExtensions:
         extension = setup_method_fixture(extension_class)
         assert extension.get_part_snippet(plugin_name="colcon") == {
             "build-environment": [{"ROS_VERSION": "2"}, {"ROS_DISTRO": "lyrical"}],
-            "colcon-ros-build-snaps": [meta_dev],
+            "colcon-ros-build-snaps": [f"{meta_dev}/edge"],
             "colcon-cmake-args": [
                 f'-DCMAKE_SYSTEM_PREFIX_PATH="/snap/{meta_dev}/current/usr"'
             ],

--- a/tests/unit/parts/extensions/test_ros2_lyrical_meta.py
+++ b/tests/unit/parts/extensions/test_ros2_lyrical_meta.py
@@ -174,6 +174,7 @@ class TestExtensionROS2LyricalMetaExtensions:
             f"{extension_name}/ros2-launch": {
                 "source": f"{get_extensions_data_dir()}/ros2",
                 "plugin": "make",
+                "make-parameters": ["DESTDIR=${CRAFT_PART_INSTALL}"],
                 "build-packages": [
                     "ros-lyrical-ros-environment",
                     "ros-lyrical-ros-workspace",

--- a/tests/unit/parts/extensions/test_ros2_lyrical_meta.py
+++ b/tests/unit/parts/extensions/test_ros2_lyrical_meta.py
@@ -173,7 +173,7 @@ class TestExtensionROS2LyricalMetaExtensions:
         extension = setup_method_fixture(extension_class)
         assert extension.get_part_snippet(plugin_name="colcon") == {
             "build-environment": [{"ROS_VERSION": "2"}, {"ROS_DISTRO": "lyrical"}],
-            "colcon-ros-build-snaps": [f"{meta_dev}/edge"],
+            "colcon-ros-build-snaps": [meta_dev],
             "colcon-cmake-args": [
                 f'-DCMAKE_SYSTEM_PREFIX_PATH="/snap/{meta_dev}/current/usr"'
             ],
@@ -203,6 +203,12 @@ class TestExtensionROS2LyricalMetaExtensions:
                     "ros-lyrical-ros-workspace",
                     "ros-lyrical-ament-index-cpp",
                     "ros-lyrical-ament-index-python",
+                    "libpython3.14-minimal",
+                    "libpython3.14-stdlib",
+                    "python3-minimal",
+                    "python3.14-minimal",
+                    "python3.14-venv",
+                    "python3-yaml",
                 ],
             }
         }

--- a/tests/unit/parts/extensions/test_ros2_lyrical_meta.py
+++ b/tests/unit/parts/extensions/test_ros2_lyrical_meta.py
@@ -190,7 +190,6 @@ class TestExtensionROS2LyricalMetaExtensions:
             f"{extension_name}/ros2-launch": {
                 "source": f"{get_extensions_data_dir()}/ros2",
                 "plugin": "make",
-                "make-parameters": ["DESTDIR=${CRAFT_PART_INSTALL}"],
                 "build-packages": [
                     "ros-lyrical-ros-environment",
                     "ros-lyrical-ros-workspace",

--- a/tests/unit/parts/plugins/test_colcon.py
+++ b/tests/unit/parts/plugins/test_colcon.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2026 Canonical Ltd
+# Copyright (C) 2020 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as

--- a/tests/unit/parts/plugins/test_colcon.py
+++ b/tests/unit/parts/plugins/test_colcon.py
@@ -838,22 +838,18 @@ class TestPluginColconPlugin:
             'rm -f "${CRAFT_PART_INSTALL}/.installed_packages.txt"',
             'rm -f "${CRAFT_PART_INSTALL}/.build_snaps.txt"',
             "if [ -d /snap/foo/current/opt/ros ]; then",
-            "AMENT_PREFIX_PATH=/snap/foo/current/opt/ros/${ROS_DISTRO}/:/snap/foo/current/opt/ros/snap/ ros2 pkg list | (xargs "
-            'rosdep resolve --rosdistro "${ROS_DISTRO}" || echo "") | awk '
-            '"/#apt/{getline;print;}" >> '
-            '"${CRAFT_PART_INSTALL}/.installed_packages.txt"',
+            "AMENT_PREFIX_PATH=/snap/foo/current/opt/ros/${ROS_DISTRO}/:/snap/foo/current/opt/ros/snap/ ros2 pkg list "
+            '>> "${CRAFT_PART_INSTALL}/.installed_packages.txt"',
             "fi",
             'if [ -d "/snap/foo/current/opt/ros/${ROS_DISTRO}/" ]; then',
             'rosdep keys --rosdistro "${ROS_DISTRO}" --from-paths '
-            '"/snap/foo/current/opt/ros/${ROS_DISTRO}/" --ignore-packages-from-source | '
-            '(xargs rosdep resolve --rosdistro "${ROS_DISTRO}" || echo "") | grep -v "#" '
-            '>> "${CRAFT_PART_INSTALL}"/.installed_packages.txt',
+            '"/snap/foo/current/opt/ros/${ROS_DISTRO}/" --ignore-packages-from-source '
+            '>> "${CRAFT_PART_INSTALL}/.installed_packages.txt"',
             "fi",
             'if [ -d "/snap/foo/current/opt/ros/snap/" ]; then',
             'rosdep keys --rosdistro "${ROS_DISTRO}" --from-paths '
-            '"/snap/foo/current/opt/ros/snap/" --ignore-packages-from-source | (xargs '
-            'rosdep resolve --rosdistro "${ROS_DISTRO}" || echo "") | grep -v "#" >> '
-            '"${CRAFT_PART_INSTALL}"/.installed_packages.txt',
+            '"/snap/foo/current/opt/ros/snap/" --ignore-packages-from-source '
+            '>> "${CRAFT_PART_INSTALL}/.installed_packages.txt"',
             "fi",
             "",
             'rosdep install --default-yes --ignore-packages-from-source --from-paths "${CRAFT_PART_SRC_WORK}"',

--- a/tests/unit/parts/plugins/test_colcon.py
+++ b/tests/unit/parts/plugins/test_colcon.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright (C) 2020 Canonical Ltd
+# Copyright (C) 2026 Canonical Ltd
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -220,6 +220,15 @@ class TestPluginColconPlugin:
             "ros-jazzy-ros2pkg",
         }
 
+    def test_get_build_packages_core26(self, setup_method_fixture, new_dir):
+        plugin = setup_method_fixture("core26", new_dir)
+
+        assert plugin.get_build_packages() == {
+            "python3-colcon-common-extensions",
+            "python3-rosdep",
+            "ros-lyrical-ros2pkg",
+        }
+
     def test_get_build_snaps(self, setup_method_fixture, new_dir):
         plugin = setup_method_fixture("core22", new_dir)
 
@@ -407,6 +416,84 @@ class TestPluginColconPlugin:
             '--ros-version "${ROS_VERSION}" --ros-distro "${ROS_DISTRO}" '
             '--target-arch "${CRAFT_TARGET_ARCH}" '
             f"--stage-cache-dir {new_dir} --base core24",
+        ]
+
+    def test_get_build_commands_core26(
+        self, setup_method_fixture, new_dir, monkeypatch
+    ):
+        plugin = setup_method_fixture("core26", new_dir)
+
+        monkeypatch.setattr(sys, "path", ["", "/test"])
+        monkeypatch.setattr(sys, "executable", "/test/python3")
+        monkeypatch.setattr(_ros, "__file__", "/test/_ros.py")
+        monkeypatch.setattr(os, "environ", {})
+
+        assert plugin.get_build_commands() == [
+            "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then",
+            "sudo --preserve-env=http_proxy,https_proxy rosdep init; fi",
+            'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
+            'state="$(set +o); set -$-"',
+            "set +u",
+            "",
+            "## Sourcing ROS ws in build snaps",
+            "## Sourcing ROS ws in stage snaps",
+            'if [ -f "${CRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/local_setup.sh" ]; then',
+            'AMENT_CURRENT_PREFIX="${CRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}" . "${CRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/local_setup.sh"',
+            "fi",
+            'if [ -f "${CRAFT_PART_INSTALL}/opt/ros/snap/local_setup.sh" ]; then',
+            'COLCON_CURRENT_PREFIX="${CRAFT_PART_INSTALL}/opt/ros/snap" . "${CRAFT_PART_INSTALL}/opt/ros/snap/local_setup.sh"',
+            "fi",
+            "",
+            "## Sourcing ROS ws in system",
+            'if [ -f "/opt/ros/${ROS_DISTRO}/local_setup.sh" ]; then',
+            'AMENT_CURRENT_PREFIX="/opt/ros/${ROS_DISTRO}" . "/opt/ros/${ROS_DISTRO}/local_setup.sh"',
+            "fi",
+            'if [ -f "/opt/ros/snap/local_setup.sh" ]; then',
+            'COLCON_CURRENT_PREFIX="/opt/ros/snap" . "/opt/ros/snap/local_setup.sh"',
+            "fi",
+            "",
+            'eval "${state}"',
+            'rm -f "${CRAFT_PART_INSTALL}/.installed_packages.txt"',
+            'rm -f "${CRAFT_PART_INSTALL}/.build_snaps.txt"',
+            'rosdep install --default-yes --ignore-packages-from-source --from-paths "${CRAFT_PART_SRC_WORK}"',
+            'state="$(set +o); set -$-"',
+            "set +u",
+            "",
+            "## Sourcing ROS ws in build snaps",
+            "## Sourcing ROS ws in stage snaps",
+            'if [ -f "${CRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/local_setup.sh" ]; then',
+            'AMENT_CURRENT_PREFIX="${CRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}" . "${CRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/local_setup.sh"',
+            "fi",
+            'if [ -f "${CRAFT_PART_INSTALL}/opt/ros/snap/local_setup.sh" ]; then',
+            'COLCON_CURRENT_PREFIX="${CRAFT_PART_INSTALL}/opt/ros/snap" . "${CRAFT_PART_INSTALL}/opt/ros/snap/local_setup.sh"',
+            "fi",
+            "",
+            "## Sourcing ROS ws in system",
+            'if [ -f "/opt/ros/${ROS_DISTRO}/local_setup.sh" ]; then',
+            'AMENT_CURRENT_PREFIX="/opt/ros/${ROS_DISTRO}" . "/opt/ros/${ROS_DISTRO}/local_setup.sh"',
+            "fi",
+            'if [ -f "/opt/ros/snap/local_setup.sh" ]; then',
+            'COLCON_CURRENT_PREFIX="/opt/ros/snap" . "/opt/ros/snap/local_setup.sh"',
+            "fi",
+            "",
+            'eval "${state}"',
+            "## Build command",
+            "colcon build "
+            '--base-paths "${CRAFT_PART_SRC_WORK}" --build-base "${CRAFT_PART_BUILD}" '
+            '--merge-install --install-base "${CRAFT_PART_INSTALL}/opt/ros/snap" '
+            "--cmake-args -DCMAKE_BUILD_TYPE=Release "
+            '--parallel-workers "${CRAFT_PARALLEL_BUILD_COUNT}"',
+            "## Post build command",
+            'if [ -f "${CRAFT_PART_INSTALL}"/opt/ros/snap/COLCON_IGNORE ]; then',
+            'rm "${CRAFT_PART_INSTALL}"/opt/ros/snap/COLCON_IGNORE',
+            "fi",
+            "env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 /test/python3 -I "
+            "/test/_ros.py "
+            'stage-runtime-dependencies --part-src "${CRAFT_PART_SRC_WORK}" '
+            '--part-install "${CRAFT_PART_INSTALL}" '
+            '--ros-version "${ROS_VERSION}" --ros-distro "${ROS_DISTRO}" '
+            '--target-arch "${CRAFT_TARGET_ARCH}" '
+            f"--stage-cache-dir {new_dir} --base core26",
         ]
 
     def test_get_build_commands_with_all_properties_core22(
@@ -679,6 +766,146 @@ class TestPluginColconPlugin:
             '--ros-version "${ROS_VERSION}" --ros-distro "${ROS_DISTRO}" '
             '--target-arch "${CRAFT_TARGET_ARCH}" '
             f"--stage-cache-dir {new_dir} --base core24",
+        ]
+
+    def test_get_build_commands_with_all_properties_core26(
+        self, setup_method_fixture, new_dir, monkeypatch
+    ):
+        plugin = setup_method_fixture(
+            "core26",
+            new_dir,
+            properties={
+                "source": ".",
+                "colcon-ament-cmake-args": ["ament", "args..."],
+                "colcon-catkin-cmake-args": ["catkin", "args..."],
+                "colcon-cmake-args": ["cmake", "args..."],
+                "colcon-packages": ["package1", "package2..."],
+                "colcon-packages-ignore": ["ipackage1", "ipackage2..."],
+                "colcon-ros-build-snaps": ["foo"],
+            },
+        )
+
+        monkeypatch.setattr(sys, "path", ["", "/test"])
+        monkeypatch.setattr(sys, "executable", "/test/python3")
+        monkeypatch.setattr(_ros, "__file__", "/test/_ros.py")
+        monkeypatch.setattr(
+            os,
+            "environ",
+            {
+                "FOO": "baR",
+                "PATH": "/bin:/test",
+                "SNAP": "TESTSNAP",
+                "SNAP_ARCH": "TESTARCH",
+                "SNAP_NAME": "TESTSNAPNAME",
+                "SNAP_VERSION": "TESTV1",
+                "http_proxy": "http://foo",
+                "https_proxy": "https://bar",
+            },
+        )
+
+        assert plugin.get_build_commands() == [
+            "if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then",
+            "sudo --preserve-env=http_proxy,https_proxy rosdep init; fi",
+            'rosdep update --include-eol-distros --rosdistro "${ROS_DISTRO}"',
+            'state="$(set +o); set -$-"',
+            "set +u",
+            "",
+            "## Sourcing ROS ws in build snaps",
+            'if [ -f "/snap/foo/current/opt/ros/${ROS_DISTRO}/local_setup.sh" ]; then',
+            'AMENT_CURRENT_PREFIX="/snap/foo/current/opt/ros/${ROS_DISTRO}" . "/snap/foo/current/opt/ros/${ROS_DISTRO}/local_setup.sh"',
+            "fi",
+            'if [ -f "/snap/foo/current/opt/ros/snap/local_setup.sh" ]; then',
+            'COLCON_CURRENT_PREFIX="/snap/foo/current/opt/ros/snap" . "/snap/foo/current/opt/ros/snap/local_setup.sh"',
+            "fi",
+            "",
+            "## Sourcing ROS ws in stage snaps",
+            'if [ -f "${CRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/local_setup.sh" ]; then',
+            'AMENT_CURRENT_PREFIX="${CRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}" . "${CRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/local_setup.sh"',
+            "fi",
+            'if [ -f "${CRAFT_PART_INSTALL}/opt/ros/snap/local_setup.sh" ]; then',
+            'COLCON_CURRENT_PREFIX="${CRAFT_PART_INSTALL}/opt/ros/snap" . "${CRAFT_PART_INSTALL}/opt/ros/snap/local_setup.sh"',
+            "fi",
+            "",
+            "## Sourcing ROS ws in system",
+            'if [ -f "/opt/ros/${ROS_DISTRO}/local_setup.sh" ]; then',
+            'AMENT_CURRENT_PREFIX="/opt/ros/${ROS_DISTRO}" . "/opt/ros/${ROS_DISTRO}/local_setup.sh"',
+            "fi",
+            'if [ -f "/opt/ros/snap/local_setup.sh" ]; then',
+            'COLCON_CURRENT_PREFIX="/opt/ros/snap" . "/opt/ros/snap/local_setup.sh"',
+            "fi",
+            "",
+            'eval "${state}"',
+            'rm -f "${CRAFT_PART_INSTALL}/.installed_packages.txt"',
+            'rm -f "${CRAFT_PART_INSTALL}/.build_snaps.txt"',
+            "if [ -d /snap/foo/current/opt/ros ]; then",
+            "AMENT_PREFIX_PATH=/snap/foo/current/opt/ros/${ROS_DISTRO}/:/snap/foo/current/opt/ros/snap/ ros2 pkg list | (xargs "
+            'rosdep resolve --rosdistro "${ROS_DISTRO}" || echo "") | awk '
+            '"/#apt/{getline;print;}" >> '
+            '"${CRAFT_PART_INSTALL}/.installed_packages.txt"',
+            "fi",
+            'if [ -d "/snap/foo/current/opt/ros/${ROS_DISTRO}/" ]; then',
+            'rosdep keys --rosdistro "${ROS_DISTRO}" --from-paths '
+            '"/snap/foo/current/opt/ros/${ROS_DISTRO}/" --ignore-packages-from-source | '
+            '(xargs rosdep resolve --rosdistro "${ROS_DISTRO}" || echo "") | grep -v "#" '
+            '>> "${CRAFT_PART_INSTALL}"/.installed_packages.txt',
+            "fi",
+            'if [ -d "/snap/foo/current/opt/ros/snap/" ]; then',
+            'rosdep keys --rosdistro "${ROS_DISTRO}" --from-paths '
+            '"/snap/foo/current/opt/ros/snap/" --ignore-packages-from-source | (xargs '
+            'rosdep resolve --rosdistro "${ROS_DISTRO}" || echo "") | grep -v "#" >> '
+            '"${CRAFT_PART_INSTALL}"/.installed_packages.txt',
+            "fi",
+            "",
+            'rosdep install --default-yes --ignore-packages-from-source --from-paths "${CRAFT_PART_SRC_WORK}"',
+            'state="$(set +o); set -$-"',
+            "set +u",
+            "",
+            "## Sourcing ROS ws in build snaps",
+            'if [ -f "/snap/foo/current/opt/ros/${ROS_DISTRO}/local_setup.sh" ]; then',
+            'AMENT_CURRENT_PREFIX="/snap/foo/current/opt/ros/${ROS_DISTRO}" . "/snap/foo/current/opt/ros/${ROS_DISTRO}/local_setup.sh"',
+            "fi",
+            'if [ -f "/snap/foo/current/opt/ros/snap/local_setup.sh" ]; then',
+            'COLCON_CURRENT_PREFIX="/snap/foo/current/opt/ros/snap" . "/snap/foo/current/opt/ros/snap/local_setup.sh"',
+            "fi",
+            "",
+            "## Sourcing ROS ws in stage snaps",
+            'if [ -f "${CRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/local_setup.sh" ]; then',
+            'AMENT_CURRENT_PREFIX="${CRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}" . "${CRAFT_PART_INSTALL}/opt/ros/${ROS_DISTRO}/local_setup.sh"',
+            "fi",
+            'if [ -f "${CRAFT_PART_INSTALL}/opt/ros/snap/local_setup.sh" ]; then',
+            'COLCON_CURRENT_PREFIX="${CRAFT_PART_INSTALL}/opt/ros/snap" . "${CRAFT_PART_INSTALL}/opt/ros/snap/local_setup.sh"',
+            "fi",
+            "",
+            "## Sourcing ROS ws in system",
+            'if [ -f "/opt/ros/${ROS_DISTRO}/local_setup.sh" ]; then',
+            'AMENT_CURRENT_PREFIX="/opt/ros/${ROS_DISTRO}" . "/opt/ros/${ROS_DISTRO}/local_setup.sh"',
+            "fi",
+            'if [ -f "/opt/ros/snap/local_setup.sh" ]; then',
+            'COLCON_CURRENT_PREFIX="/opt/ros/snap" . "/opt/ros/snap/local_setup.sh"',
+            "fi",
+            "",
+            'eval "${state}"',
+            "## Build command",
+            "colcon build "
+            '--base-paths "${CRAFT_PART_SRC_WORK}" --build-base "${CRAFT_PART_BUILD}" '
+            '--merge-install --install-base "${CRAFT_PART_INSTALL}/opt/ros/snap" '
+            "--packages-ignore ipackage1 ipackage2... --packages-select package1 "
+            "package2... --cmake-args -DCMAKE_BUILD_TYPE=Release cmake args... "
+            "--ament-cmake-args ament args... --catkin-cmake-args catkin "
+            'args... --parallel-workers "${CRAFT_PARALLEL_BUILD_COUNT}"',
+            "## Post build command",
+            'if [ -f "${CRAFT_PART_INSTALL}"/opt/ros/snap/COLCON_IGNORE ]; then',
+            'rm "${CRAFT_PART_INSTALL}"/opt/ros/snap/COLCON_IGNORE',
+            "fi",
+            "env -i LANG=C.UTF-8 LC_ALL=C.UTF-8 PATH=/bin:/test SNAP=TESTSNAP "
+            "SNAP_ARCH=TESTARCH SNAP_NAME=TESTSNAPNAME SNAP_VERSION=TESTV1 "
+            "http_proxy=http://foo https_proxy=https://bar "
+            "/test/python3 -I /test/_ros.py "
+            'stage-runtime-dependencies --part-src "${CRAFT_PART_SRC_WORK}" '
+            '--part-install "${CRAFT_PART_INSTALL}" '
+            '--ros-version "${ROS_VERSION}" --ros-distro "${ROS_DISTRO}" '
+            '--target-arch "${CRAFT_TARGET_ARCH}" '
+            f"--stage-cache-dir {new_dir} --base core26",
         ]
 
     def test_get_build_commands_with_cmake_debug(


### PR DESCRIPTION
Adds support for ROS 2 Lyrical on core26, following the same pattern as the existing ROS 2 Humble (core22) and Jazzy (core24) extensions.

Changes include:

- New extension files: `ros2_lyrical.py`, `ros2_lyrical_desktop.py`, `ros2_lyrical_ros_base.py`, `ros2_lyrical_ros_core.py`, and `_ros2_lyrical_meta.py`
- Registered the new extensions in `registry.py`
- Added core26 support to the colcon plugin (`_ros.py`)
- Unit tests for the new extensions and updated `test_list_extensions.py`
- Spread tests for integration testing on core26
- Documentation updates for the how-to guide and reference pages covering the new extensions and base

The extension is currently marked as experimental.

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [X] I've successfully run `make lint && make test`.
- [X] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
