### PR TITLE
kde-neon-6 launcher-specific - link to Kvantum folder

### DIFF
--- a/extensions/desktop/kde-neon-6/launcher-specific
+++ b/extensions/desktop/kde-neon-6/launcher-specific
@@ -62,3 +62,10 @@ if [ -e "$SNAP_DESKTOP_RUNTIME/usr/share/i18n" ]; then
     export LOCPATH="$locpath:/usr/lib/locale"
     LC_ALL=C.UTF-8 async_exec "$SNAP/snap/command-chain/locale-gen"
 fi
+
+# Kvantum configuration folder
+KVANTUM_CONFIG_PATH="$XDG_CONFIG_HOME/Kvantum"
+if [ ! -L "$KVANTUM_CONFIG_PATH" ] && [ -d "$SNAP_REAL_HOME/.config/Kvantum" ]; then
+    ensure_dir_exists "$(dirname "$KVANTUM_CONFIG_PATH")"
+    ln -sfn "$SNAP_REAL_HOME/.config/Kvantum" "$KVANTUM_CONFIG_PATH"
+fi


### PR DESCRIPTION
<!-- Describe your changes -->
This is simply creating a symlink so that Kvantum can find external themes.

Currently, Snapd already has permission to read the $SNAP_REAL_HOME/.config/Kvantum folder, but without the symlink, Kvantum is only able to read the configuration file.

As far as I know, this also needs to be changed here:
https://invent.kde.org/neon/snap-packaging/snapcraft-desktop-integration/-/blob/master/common/desktop-exports?ref_type=heads
https://invent.kde.org/neon/snap-packaging/snapcraft-desktop-integration/-/blob/work.core24/common/desktop-exports?ref_type=heads

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
