### PR TITLE
docs: add gnome-keyring example for WSL users (fixes #6049)

### DIFF
--- a/docs/how-to/publishing/authenticate.rst
+++ b/docs/how-to/publishing/authenticate.rst
@@ -118,3 +118,19 @@ Note that ``snapcraft login`` sometimes fails to unlock GNOME keyring when acces
 Linux system with a desktop environment from a virtual console or SSH. GNOME keyring
 will not present a CLI password prompt to unlock the keyring, causing Snapcraft to stall
 and timeout.
+
+Example (WSL users):
+
+On WSL systems, you may need to install a system keyring such as
+``gnome-keyring`` manually:
+
+.. code-block:: bash
+
+   sudo apt update
+   sudo apt install --assume-yes gnome-keyring
+
+After installation, restart your shell and run:
+
+.. code-block:: bash
+
+   snapcraft login


### PR DESCRIPTION
Adds a concrete example of installing and configuring gnome-keyring
for WSL users, as suggested in issue #6049.

Fixes #6049.