### PR TITLE
chore: remove comment fences from GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Bug description
       value: >
-        <!-- Describe the bug, including any relevant context or screenshots. -->
+        Describe the bug, including any relevant context or screenshots.
     validations:
       required: true
   - type: textarea
@@ -22,7 +22,7 @@ body:
     attributes:
       label: Steps to reproduce
       value: >
-        <!-- Provide step-by-step instructions to reproduce the bug. -->
+        Provide step-by-step instructions to reproduce the bug.
     validations:
       required: true
   - type: textarea
@@ -30,9 +30,9 @@ body:
     attributes:
       label: Environment
       value: >
-        <!-- We need to understand the context in which Snapcraft failed. Please let us
+        We need to understand the context in which Snapcraft failed. Please let us
         know if you are running Snapcraft in destructive mode, whether you are using LXD
-        or Multipass, and which operating system you are running Snapcraft on. -->
+        or Multipass, and which operating system you are running Snapcraft on.
     validations:
       required: true
   - type: textarea
@@ -40,15 +40,15 @@ body:
     attributes:
       label: snapcraft.yaml
       value: >
-        <!-- If the issue is specific to a project, share its `snapcraft.yaml`. This
+        If the issue is specific to a project, share its `snapcraft.yaml`. This
         field automatically renders as YAML, so you don't need to add special
-        formatting. -->
+        formatting.
       render: yaml
   - type: textarea
     id: logs
     attributes:
       label: Log output
       value: >
-        <!-- Provide any relevant logging. This field automatically renders as
-        a log, so you don't need to add special formatting. -->
+        Provide any relevant logging. This field automatically renders as
+        a log, so you don't need to add special formatting.
       render: shell

--- a/.github/ISSUE_TEMPLATE/docs.yaml
+++ b/.github/ISSUE_TEMPLATE/docs.yaml
@@ -14,8 +14,8 @@ body:
     attributes:
       label: Request
       value: >
-        <!-- Describe your request and the problem it solves. Include any relevant
-        context, screenshots, or examples. -->
+        Describe your request and the problem it solves. Include any relevant
+        context, screenshots, or examples.
     validations:
       required: true
   - type: input
@@ -23,6 +23,6 @@ body:
     attributes:
       label: Document location
       value: >
-        <!-- Provide the URL or file path of the relevant page. -->
+        Provide the URL or file path of the relevant page.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/task.yaml
+++ b/.github/ISSUE_TEMPLATE/task.yaml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Request
       value: >
-        <!-- Describe the feature you'd like to see implemented. -->
+        Describe the feature you'd like to see implemented.
     validations:
       required: true
   - type: textarea
@@ -22,6 +22,6 @@ body:
     attributes:
       label: The problem it solves
       value: >
-        <!-- Describe the impact your request would have. -->
+        Describe the impact your request would have.
     validations:
       required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Describe your changes -->
+Describe your changes.
 
 ---
 


### PR DESCRIPTION
Some contributors don't recognise the HTML markup, so it's better to leave it out.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
~~- [ ] I've successfully run `make lint && make test`.~~
~~- [ ] I've added or updated any relevant documentation.~~
~~- [ ] I've updated the relevant release notes.~~
