### PR TITLE
docs: improve discoverability of the build-packages key

### DIFF
--- a/docs/how-to/crafting/manage-dependencies.rst
+++ b/docs/how-to/crafting/manage-dependencies.rst
@@ -82,9 +82,10 @@ For staged snaps, the ``meta`` and ``snap`` directories from the snap will be av
 as ``meta.<snap-name>`` and ``snap.<snap-name>`` for cases where assets from those
 locations are desired for reuse.
 
+.. index:: build-packages
 
-Build-time packages
--------------------
+build-packages
+--------------
 
 Use ``build-packages`` to specify system packages that are required to
 build a part and are not included in the resulting snap.

--- a/docs/reference/project-file/anatomy-of-snapcraft-yaml.rst
+++ b/docs/reference/project-file/anatomy-of-snapcraft-yaml.rst
@@ -266,3 +266,5 @@ instance, a foo build package from core22 would be installed (``apt install
 foo``) in the snap build environment during build. In the case of wethr, the
 snap needs Git to retrieve the sources from a remote Git repository and sed
 to search and replace the string and yield a Git tag.
+
+For practical guidance and examples, see :ref:`how-to-manage-dependencies`.


### PR DESCRIPTION
Improve discoverability of the `build-packages` key by adding a dedicated section in the dependency management documentation.

This makes the key easier to locate through documentation search.

Fixes #6046.