### PR TITLE
init: normalize long directory-derived snap names

### DIFF
--- a/snapcraft/services/init.py
+++ b/snapcraft/services/init.py
@@ -27,9 +27,50 @@ from snapcraft import errors
 from snapcraft.models.project import validate_name
 from snapcraft.parts.yaml_utils import get_snap_project
 
+MAX_SNAP_NAME_LENGTH = 40
+
+
+def _normalize_snap_name(name: str) -> str:
+    """Normalize a derived snap name to satisfy snap naming rules.
+
+    Ensures the name does not exceed MAX_SNAP_NAME_LENGTH and does not end with '-'.
+    """
+    return name[:MAX_SNAP_NAME_LENGTH].rstrip("-")
+
+
+def _validate_snap_name(name: str) -> None:
+    """Validate a snap name against snap naming rules."""
+    validate_name(name=name, field_name="snap")
+    if len(name) > MAX_SNAP_NAME_LENGTH:
+        raise ValueError(
+            f"snap names must be {MAX_SNAP_NAME_LENGTH} characters or less"
+        )
+
 
 class Init(services.InitService):
     """Service class for initializing a project."""
+
+    @override
+    def validate_project_name(self, name: str, *, use_default: bool = False) -> str:
+        """Validate a snap project name.
+
+        If the name is derived from the directory (`use_default=True`), normalize it
+        before validating it against snap naming rules.
+        """
+        if use_default:
+            name = _normalize_snap_name(name)
+
+        try:
+            _validate_snap_name(name)
+        except ValueError as err:
+            if use_default:
+                return self._default_name
+            raise errors.SnapcraftError(
+                message=f"Invalid snap name {name!r}: {str(err)}.",
+                resolution="Provide a valid name with '--name' or rename the project directory.",
+            ) from err
+
+        return name
 
     @override
     def initialise_project(
@@ -40,9 +81,7 @@ class Init(services.InitService):
         template_dir: pathlib.Path,
     ) -> None:
         try:
-            validate_name(name=project_name, field_name="snap")
-            if len(project_name) > 40:
-                raise ValueError("snap names must be 40 characters or less")
+            _validate_snap_name(project_name)
         except ValueError as err:
             raise errors.SnapcraftError(
                 message=f"Invalid snap name {project_name!r}: {str(err)}.",
@@ -72,13 +111,15 @@ class Init(services.InitService):
                 craft_cli.emit.progress("Checking for an existing 'snapcraft.yaml'.")
                 project = get_snap_project(project_dir)
             # the `ProjectMissing` error means a new project can be initialised
-            except craft_application.errors.ProjectDirectoryTypeError:
+            except craft_application.errors.ProjectDirectoryTypeError as err:
                 raise errors.SnapcraftError(
-                    "Could not initialise a new snapcraft project because "
-                    "a file named 'snap' already exists.",
+                    message=(
+                        "Could not initialise a new snapcraft project because a file named "
+                        "'snap' already exists."
+                    ),
                     details="The 'snap' name is reserved for the project directory.",
                     resolution="Rename or remove the file named 'snap'.",
-                )
+                ) from err
             except craft_application.errors.ProjectFileError:
                 craft_cli.emit.debug("Could not find an existing 'snapcraft.yaml'.")
             else:

--- a/tests/unit/commands/test_init.py
+++ b/tests/unit/commands/test_init.py
@@ -23,6 +23,7 @@ import pytest
 from snapcraft import application
 from snapcraft.models.project import Project
 from snapcraft.parts.yaml_utils import apply_yaml, process_yaml
+from snapcraft.services.init import MAX_SNAP_NAME_LENGTH
 
 
 @pytest.fixture
@@ -32,6 +33,67 @@ def valid_new_dir(tmp_path, monkeypatch):
     new_dir.mkdir()
     monkeypatch.chdir(new_dir)
     return new_dir
+
+
+@pytest.fixture
+def long_named_new_dir(tmp_path, monkeypatch):
+    """Change to a new temporary directory whose name exceeds the snap name limit."""
+    new_dir = (
+        tmp_path / "this-working-directory-has-a-very-very-long-name-over-maximum-chars"
+    )
+    new_dir.mkdir()
+    monkeypatch.chdir(new_dir)
+    return new_dir
+
+
+def test_init_default_long_directory_name(emitter, long_named_new_dir, mocker):
+    """Test 'snapcraft init' succeeds when the current directory name is too long."""
+    expected_name = long_named_new_dir.name[:MAX_SNAP_NAME_LENGTH].rstrip("-")
+
+    snapcraft_yaml = long_named_new_dir / "snap/snapcraft.yaml"
+    cmd = _create_command(profile=None, project_dir=None, name=None)
+    mocker.patch.object(sys, "argv", cmd)
+
+    app = application.create_app()
+    app.run()
+
+    assert snapcraft_yaml.exists()
+
+    data = apply_yaml(process_yaml(snapcraft_yaml), "amd64", "amd64")
+    project = Project.unmarshal(data)
+
+    assert project.name == expected_name
+
+    emitter.assert_progress("Checking for an existing 'snapcraft.yaml'.")
+    emitter.assert_debug("Could not find an existing 'snapcraft.yaml'.")
+    emitter.assert_message(
+        "See https://documentation.ubuntu.com/snapcraft/stable/reference/project-file "
+        "for reference information about the snapcraft.yaml format."
+    )
+    emitter.assert_message("Successfully initialised project.")
+
+
+def test_init_default_explicit_long_name_fails(valid_new_dir, mocker, capsys):
+    """Test 'snapcraft init --name' fails for names longer than the snap limit."""
+    long_name = "a" * (MAX_SNAP_NAME_LENGTH + 1)
+    snapcraft_yaml = valid_new_dir / "snap/snapcraft.yaml"
+    cmd = _create_command(profile=None, project_dir=None, name=long_name)
+    mocker.patch.object(sys, "argv", cmd)
+
+    app = application.create_app()
+    app.run()
+
+    captured = capsys.readouterr()
+
+    assert "Invalid snap name" in captured.err
+    assert (
+        f"snap names must be {MAX_SNAP_NAME_LENGTH} characters or less" in captured.err
+    )
+    assert (
+        "Provide a valid name with '--name' or rename the project directory."
+        in captured.err
+    )
+    assert not snapcraft_yaml.exists()
 
 
 def _create_command(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -339,6 +339,15 @@ def fake_provider(mock_instance):
     class FakeProvider(Provider):
         """Fake provider."""
 
+        def list_instances(
+            self,
+            *,
+            project_name: str | None = None,
+            instance_name_prefix: str | None = None,
+            include_base_instances: bool = False,
+        ):
+            return []
+
         @property
         @override
         def name(self) -> str:

--- a/tests/unit/services/test_init.py
+++ b/tests/unit/services/test_init.py
@@ -23,6 +23,7 @@ import pytest
 
 from snapcraft import errors
 from snapcraft.parts.yaml_utils import _SNAP_PROJECT_FILES
+from snapcraft.services.init import MAX_SNAP_NAME_LENGTH, _normalize_snap_name
 
 
 @pytest.fixture()
@@ -67,7 +68,7 @@ def test_init_valid_name(name, init_service, new_dir, emitter):
 
 
 @pytest.mark.parametrize(
-    "name,error",
+    "name, error",
     [
         ("name_with_underscores", "snap names can only use"),
         ("name-with-UPPERCASE", "snap names can only use"),
@@ -78,7 +79,7 @@ def test_init_valid_name(name, init_service, new_dir, emitter):
         ("123456", "snap names can only use"),
         (
             "a2345678901234567890123456789012345678901",
-            "snap names must be 40 characters or less",
+            f"snap names must be {MAX_SNAP_NAME_LENGTH} characters or less",
         ),
     ],
 )
@@ -111,6 +112,20 @@ def test_init_snap_dir_exists(init_service, new_dir, emitter):
         "See https://documentation.ubuntu.com/snapcraft/stable/reference/project-file "
         "for reference information about the snapcraft.yaml format."
     )
+
+
+def test_normalize_snap_name_truncates():
+    """Long derived names are truncated to the maximum snap name length."""
+    long_name = "a" * (MAX_SNAP_NAME_LENGTH + 10)
+
+    assert _normalize_snap_name(long_name) == long_name[:MAX_SNAP_NAME_LENGTH]
+
+
+def test_normalize_snap_name_removes_trailing_hyphen():
+    """Trailing hyphens are removed after truncation."""
+    name = ("a" * (MAX_SNAP_NAME_LENGTH - 1)) + "-extra"
+
+    assert _normalize_snap_name(name) == ("a" * (MAX_SNAP_NAME_LENGTH - 1))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Fix `snapcraft init` when the current directory name is longer than the snap name limit.

When the project name is derived automatically from the directory, Snapcraft now:

- truncates it to the maximum snap name length
- removes a trailing hyphen after truncation
- validates the normalized name before project initialization

Explicit names passed with `--name` keep the existing strict validation behaviour.

Closes #6093.

## Why

Today, `snapcraft init` fails if the current working directory name is longer than 40 characters, even though other Craft tools initialize successfully in equivalent cases.

This change keeps the special handling limited to directory-derived names and avoids changing the contract for explicit `--name` values.

## Implementation

- add `MAX_SNAP_NAME_LENGTH`
- add `_normalize_snap_name()` for directory-derived names
- add `_validate_snap_name()` to centralize snap-specific validation, including the 40-character limit
- override `validate_project_name(..., use_default=True)` so only directory-derived names are normalized
- keep `initialise_project()` strict for explicit project names
- preserve exception chaining for the reserved `snap/` directory path error

## Tests

Added or updated tests to cover:

- explicit invalid names still failing in the init service
- normalization helper behaviour:
  - truncation
  - trailing hyphen removal
- `snapcraft init` succeeding when the current directory name is too long
- `snapcraft init --name <long-name>` still failing and not creating `snap/snapcraft.yaml`

Also updated the fake provider test double to implement `list_instances()` with the current provider interface so the unit tests remain compatible.
