### PR TITLE
build(deps): constrain setuptools-scm due to cyclic dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,8 @@ constraint-dependencies = [
 build-constraint-dependencies = [
     # needed until we have rustc >= 1.78
     "maturin<1.10.0 ; python_version < '3.14'",
+    # Circular dependency with setuptools 10.0 see https://github.com/pypa/setuptools-scm/issues/1302
+    "setuptools-scm!=10.0.2,!=10.0.3",
 ]
 
 [[tool.uv.index]]

--- a/uv.lock
+++ b/uv.lock
@@ -20,7 +20,10 @@ constraints = [
     { name = "protobuf", specifier = "==6.32.*" },
     { name = "pynacl", specifier = "<1.6.0" },
 ]
-build-constraints = [{ name = "maturin", marker = "python_full_version < '3.14'", specifier = "<1.10.0" }]
+build-constraints = [
+    { name = "maturin", marker = "python_full_version < '3.14'", specifier = "<1.10.0" },
+    { name = "setuptools-scm", specifier = "!=10.0.2,!=10.0.3" },
+]
 
 [[package]]
 name = "accessible-pygments"


### PR DESCRIPTION
Workaround for https://github.com/pypa/setuptools-scm/issues/1302

Snap build not tested yet, but it works with `UV_PYTHON=3.12 UV_PYTHON_DOWNLOADS=never UV_NO_BINARY=1 uv sync --frozen --no-dev --no-editable --no-cache`

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
