### PR TITLE
docs: mention removing passthrough in core20 to core22 migration

### DIFF
--- a/docs/how-to/change-bases/change-from-core20-to-core22.rst
+++ b/docs/how-to/change-bases/change-from-core20-to-core22.rst
@@ -193,34 +193,6 @@ to core22 as follows:
     * - ``SNAPCRAFT_PART_INSTALL``
       - ``CRAFT_PART_INSTALL``
 
-Remove ``passthrough`` key
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-For production snaps, remove the ``passthrough`` key.
-Historically, ``passthrough`` allowed experimental data to be forwarded to snapd,
-but the Snap store doesn't permit this key.
-
-For example, if a hook uses ``passthrough`` only to define an environment, migrate:
-
-.. code-block:: yaml
-    :caption: snapcraft.yaml
-
-    hooks:
-      configure:
-        passthrough:
-          environment:
-            FOO: BAR
-
-to:
-
-.. code-block:: yaml
-    :caption: snapcraft.yaml
-
-    hooks:
-      configure:
-        environment:
-          FOO: BAR
-
 
 Get the grade
 ~~~~~~~~~~~~~
@@ -480,6 +452,29 @@ The following environment variable names should be migrated as follows:
       - ``PARTS_PYTHON_INTERPRETER``
     * - ``SNAPCRAFT_PYTHON_VENV_ARGS``
       - ``PARTS_PYTHON_VENV_ARGS``
+
+
+Remove ``passthrough`` keys
+---------------------------
+
+If your snap is meant for public consumption, remove any instances of the
+``passthrough`` key in all structures. These keys are for experimental data to be
+forwarded to SnapD in test environments, and as of core22 the Snap Store flags it during
+automatic review.
+
+For example, if a hook sets an experimental environment variable, you'd remove the key
+like this:
+
+.. code-block:: diff
+    :caption: snapcraft.yaml
+
+     hooks:
+       configure:
+    -    passthrough:
+    -      environment:
+    -        FOO: BAR
+    +    environment:
+    +      FOO: BAR
 
 
 Destructive mode


### PR DESCRIPTION
## Summary
- mention that `passthrough` should be removed for production snaps targeting core22 and newer
- add a migration example showing how hook environment data can be moved out of `passthrough`

Closes #5986