### PR TITLE
build: constrain setuptools-scm<10.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,7 @@ build-constraint-dependencies = [
     # needed until we have rustc >= 1.78
     "maturin<1.10.0 ; python_version < '3.14'",
     # Circular dependency with setuptools 10.0 see https://github.com/pypa/setuptools-scm/issues/1302
-    "setuptools-scm!=10.0.2,!=10.0.3",
+    "setuptools-scm<10.0.2",
 ]
 
 [[tool.uv.index]]

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ constraints = [
 ]
 build-constraints = [
     { name = "maturin", marker = "python_full_version < '3.14'", specifier = "<1.10.0" },
-    { name = "setuptools-scm", specifier = "!=10.0.2,!=10.0.3" },
+    { name = "setuptools-scm", specifier = "<10.0.2" },
 ]
 
 [[package]]


### PR DESCRIPTION
10.0.4 was released about half an hour ago and is still broken in source builds.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
