### PR TITLE
docs: re-order migration guide

### DIFF
--- a/docs/how-to/change-bases/change-from-core24-to-core26.rst
+++ b/docs/how-to/change-bases/change-from-core24-to-core26.rst
@@ -12,17 +12,6 @@ Core26 is built from Ubuntu 26.04 LTS. For most snaps, the migration consists of
 checking dependencies and extensions. If your snap has strict confinement and runs
 Python code, you need to add a Python runtime.
 
-Stability and workarounds
--------------------------
-
-In the wake of a new core, some of the updated features and packages your snap relies on
-will be unstable for a time.
-
-This is to be expected with complex software. A short-term fix or workaround in your
-snap's parts, packages, and scriptlets might be needed. But sometimes, a temporary fix
-becomes permanent. It's a good practice to explain your workarounds with comments in
-your project's ``snapcraft.yaml``.
-
 Update the base
 ---------------
 
@@ -33,6 +22,17 @@ Start by updating the ``base`` key:
 
     - base: core24
     + base: core26
+
+Stability and workarounds
+-------------------------
+
+In the wake of a new core, some of the updated features and packages your snap relies on
+will be unstable for a time.
+
+This is to be expected with complex software. A short-term fix or workaround in your
+snap's parts, packages, and scriptlets might be needed. But sometimes, a temporary fix
+becomes permanent. It's a good practice to explain your workarounds with comments in
+your project's ``snapcraft.yaml``.
 
 Check extension support
 -----------------------


### PR DESCRIPTION
I realized I didn't like the order I put these in.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
