### PR TITLE
fix: .NET runtime slot name in error message

### DIFF
--- a/extensions/dotnet/launcher.sh
+++ b/extensions/dotnet/launcher.sh
@@ -7,7 +7,7 @@ fi
 
 if ! snapctl is-connected "${DOTNET_EXT_PLUG_NAME}"; then
   >&2 echo "Plug '${DOTNET_EXT_PLUG_NAME}' isn't connected."
-  >&2 echo "Please run: 'snap connect ${DOTNET_EXT_SNAP_NAME}:${DOTNET_EXT_PLUG_NAME} ${DOTNET_EXT_CONTENT_SNAP}:${DOTNET_EXT_PLUG_NAME}'."
+  >&2 echo "Please run: 'snap connect ${DOTNET_EXT_SNAP_NAME}:${DOTNET_EXT_PLUG_NAME} ${DOTNET_EXT_CONTENT_SNAP}:dotnet-runtime'."
   exit 1
 fi
 


### PR DESCRIPTION
The slot name for every .NET runtime content snap is called `dotnet-runtime`.

The error message for when the runtime plug is not connected should use that string instead of the application's plug name, since they differ.

e.g.:
```
Plug 'dotnet8' isn't connected.
Please run: 'snap connect foo:dotnet8 dotnet-runtime-80:dotnet-runtime'.
```

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
