### PR TITLE
test: fix core26 python tests

### DIFF
--- a/tests/spread/core26/python-hello/classic/snap/snapcraft.yaml
+++ b/tests/spread/core26/python-hello/classic/snap/snapcraft.yaml
@@ -23,8 +23,8 @@ parts:
     build-attributes:
       - enable-patchelf
     stage-packages:
-      - libpython3.13-minimal
-      - libpython3.13-stdlib
-      - python3.13-minimal
+      - libpython3.14-minimal
+      - libpython3.14-stdlib
+      - python3.14-minimal
       - python3-venv
       - python3-minimal # (for the "python3" symlink)

--- a/tests/spread/core26/python-hello/poetry/snap/snapcraft.yaml
+++ b/tests/spread/core26/python-hello/poetry/snap/snapcraft.yaml
@@ -15,8 +15,8 @@ parts:
     plugin: poetry
     source: src
     stage-packages:
-      - libpython3.13-minimal
-      - libpython3.13-stdlib
-      - python3.13-minimal
+      - libpython3.14-minimal
+      - libpython3.14-stdlib
+      - python3.14-minimal
       - python3-venv
       - python3-minimal # (for the "python3" symlink)

--- a/tests/spread/core26/python-hello/strict/snap/snapcraft.yaml
+++ b/tests/spread/core26/python-hello/strict/snap/snapcraft.yaml
@@ -17,8 +17,8 @@ parts:
     python-packages:
       - black
     stage-packages:
-      - libpython3.13-minimal
-      - libpython3.13-stdlib
-      - python3.13-minimal
+      - libpython3.14-minimal
+      - libpython3.14-stdlib
+      - python3.14-minimal
       - python3-venv
       - python3-minimal # (for the "python3" symlink)

--- a/tests/spread/core26/python-hello/uv/snap/snapcraft.yaml
+++ b/tests/spread/core26/python-hello/uv/snap/snapcraft.yaml
@@ -17,8 +17,8 @@ parts:
     build-snaps:
       - astral-uv
     stage-packages:
-      - libpython3.13-minimal
-      - libpython3.13-stdlib
-      - python3.13-minimal
+      - libpython3.14-minimal
+      - libpython3.14-stdlib
+      - python3.14-minimal
       - python3-venv
       - python3-minimal # (for the "python3" symlink)


### PR DESCRIPTION
Update the core26 python spread tests to use python 3.14.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
