### PR TITLE
test(spread): add core26 package-cutoff test 

### DIFF
--- a/tests/spread/_common/package-cutoff/snapcraft.yaml
+++ b/tests/spread/_common/package-cutoff/snapcraft.yaml
@@ -1,0 +1,14 @@
+name: package-cutoff
+base: core24
+version: "1.0"
+summary: "test"
+description: test
+
+grade: devel
+confinement: devmode
+
+parts:
+  package-cutoff:
+    plugin: nil
+    stage-packages:
+      - liblzma5

--- a/tests/spread/_common/package-cutoff/task.yaml
+++ b/tests/spread/_common/package-cutoff/task.yaml
@@ -1,3 +1,5 @@
+# Regression test for https://github.com/canonical/snapcraft/issues/6148
+
 summary: Verify stage packages cutoff works
 
 prepare: |

--- a/tests/spread/_common/package-cutoff/task.yaml
+++ b/tests/spread/_common/package-cutoff/task.yaml
@@ -1,0 +1,23 @@
+summary: Verify stage packages cutoff works
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "snapcraft.yaml"
+
+execute: |
+  snapcraft pack
+  test -f "package-cutoff_1.0_amd64.snap"
+
+  # Verify libc6 was not staged in the snap (i.e. package cutoff is working)
+  unsquashfs package-cutoff_1.0_amd64.snap
+  find squashfs-root -name "libc.so*" | NOMATCH "libc.so"
+
+restore: |
+  snapcraft clean
+  rm -f ./*.snap
+  rm -rf squashfs-root
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snapcraft.yaml"

--- a/tests/spread/core22/package-cutoff
+++ b/tests/spread/core22/package-cutoff
@@ -1,0 +1,1 @@
+../_common/package-cutoff

--- a/tests/spread/core24/package-cutoff
+++ b/tests/spread/core24/package-cutoff
@@ -1,0 +1,1 @@
+../_common/package-cutoff

--- a/tests/spread/core26/package-cutoff
+++ b/tests/spread/core26/package-cutoff
@@ -1,0 +1,1 @@
+../_common/package-cutoff

--- a/tests/spread/tools/snapcraft-yaml.sh
+++ b/tests/spread/tools/snapcraft-yaml.sh
@@ -2,11 +2,13 @@
 
 get_base()
 {
-    if [[ "$SPREAD_SYSTEM" =~ ubuntu-26.04 ]]; then
+    # SPREAD_SUITE contains the path to the task.yaml (like tests/spread/core26/package-cutoff)
+    # so matching on this first allows testing new bases before their corresponding Ubuntu release is available
+    if [[ "$SPREAD_SUITE" =~ core26 ]] || [[ "$SPREAD_SYSTEM" =~ ubuntu-26.04 ]]; then
         echo "core26"
-    elif [[ "$SPREAD_SYSTEM" =~ ubuntu-24.04 ]]; then
+    elif [[ "$SPREAD_SUITE" =~ core24 ]] || [[ "$SPREAD_SYSTEM" =~ ubuntu-24.04 ]]; then
         echo "core24"
-    elif [[ "$SPREAD_SYSTEM" =~ ubuntu-22.04 ]]; then
+    elif [[ "$SPREAD_SUITE" =~ core22 ]] || [[ "$SPREAD_SYSTEM" =~ ubuntu-22.04 ]]; then
         echo "core22"
     else
         exit 1
@@ -37,6 +39,12 @@ set_base()
         else
             # Insert at the very top to be safe
             sed -i "/^base:.*/a\build-base: devel"  "$snapcraft_yaml_path"
+        fi
+
+        if grep -q "^grade:" "$snapcraft_yaml_path"; then
+            sed -i "s/^grade:.*/grade: devel/g" "$snapcraft_yaml_path"
+        else
+            sed -i "/^build-base:.*/a\grade: devel"  "$snapcraft_yaml_path"
         fi
     fi
 }


### PR DESCRIPTION
Downstream test for https://github.com/canonical/craft-parts/pull/1538.

Includes the changes from https://github.com/canonical/snapcraft/pull/6171

Fixes #6146 
Fixes #6148
(SNAPCRAFT-1327)

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
