### PR TITLE
docs: link to snap docs with intersphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -269,7 +269,7 @@ intersphinx_mapping = {
 }
 
 # Block Intersphinx from looking up external sources with internal references. In other
-# words, only :external+<project>...` will search in other projects.
+# words, only :external+<project>... will search in other projects.
 intersphinx_disabled_reftypes = ["std:*"]
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -261,12 +261,16 @@ if "discourse_prefix" not in html_context and "discourse" in html_context:
 # Add configuration for intersphinx mapping
 intersphinx_mapping = {
     # https://github.com/canonical/snapcraft/issues/6036
-    # "snap": ("https://snapcraft.io/docs/", None),
+    "snap": ("https://snapcraft.io/docs/", None),
     "charmcraft": ("https://documentation.ubuntu.com/charmcraft/stable/", None),
     "rockcraft": ("https://documentation.ubuntu.com/rockcraft/stable/", None),
     "starflow": ("https://canonical-starflow.readthedocs-hosted.com", None),
     "ubuntu-frame": ("https://canonical-ubuntu-frame-documentation.readthedocs-hosted.com/24", None),
 }
+
+# Block Intersphinx from looking up external sources with internal references. In other
+# words, only :external+<project>...` will search in other projects.
+intersphinx_disabled_reftypes = ["std:*"]
 
 
 ##############################

--- a/docs/explanation/cryptography.rst
+++ b/docs/explanation/cryptography.rst
@@ -99,16 +99,16 @@ Creating virtual build environments
 
 Snapcraft instantiates and builds snaps on self-allocated virtual instances. It uses
 the `Requests`_ library to install Multipass on Windows. Build environments for other
-operating systems are handled by the local `snap daemon (snapd)`_.
+operating systems are handled by the local :external+snap:doc:`snap daemon <index>`.
 
 Communication with snapd
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Snapcraft uses the Requests library to communicate over Unix sockets with snapd. These
 requests fetch information about required software. If the software is missing,
-Snapcraft will install it through snapd. This is done by querying the `snapd API
-<https://snapcraft.io/docs/reference/development/snapd-rest-api/>`__ with URLs built
-dynamically and sanitized by `urllib`_.
+Snapcraft will install it through snapd. This is done by querying the
+:external+snap:doc:`reference/development/snapd-rest-api` with URLs built dynamically
+and sanitized by `urllib`_.
 
 Sources
 ~~~~~~~
@@ -300,6 +300,5 @@ is invoked by the consuming application.
 .. _macaroons: https://research.google/pubs/macaroons-cookies-with-contextual-caveats-for-decentralized-authorization-in-the-cloud/
 .. _Mercurial: https://www.mercurial-scm.org/
 .. _Requests: https://requests.readthedocs.io/
-.. _snap daemon (snapd): https://snapcraft.io/docs/installing-snapd
 .. _Subversion: https://subversion.apache.org/
 .. _urllib: https://docs.python.org/3/library/urllib.html

--- a/docs/explanation/interfaces.rst
+++ b/docs/explanation/interfaces.rst
@@ -6,12 +6,12 @@ Interfaces
 A strictly-confined snap is considered untrusted and runs in a restricted environment.
 It's only able to access a limited set of resources outside the environment it runs in.
 Access to system resources and other snaps is granted on a granular basis using a
-mechanism called `interfaces <https://snapcraft.io/docs/interface-management>`_.
+mechanism called :external+snap:ref:`interfaces
+<explanation-interfaces-all-about-interfaces>`.
 
-For example, a browser without network access doesn't serve its intended purpose.
-To that end, snap developers can use the `network interface
-<https://snapcraft.io/docs/network-interface>`_ to provide network access to the
-browser.
+For example, a browser without network access doesn't serve its intended purpose. To
+that end, snap developers can use the :external+snap:ref:`interfaces-network-interface`
+to provide network access to the browser.
 
 
 Design
@@ -26,9 +26,8 @@ The plug connects to the provided interface and consumes the resource.
 
 Some interfaces connect automatically when a snap is installed, while others, such as
 those that have access to sensitive resources, need to be connected manually. See
-`Supported interfaces <https://snapcraft.io/docs/supported-interfaces>`_ for details on
+:external+snap:ref:`ref-index_interfaces` for details on
 which interfaces connect automatically.
 
 Users can control interfaces manually by connecting and disconnecting them with snapd.
-See `Interface management <https://snapcraft.io/docs/interface-management>`_ for
-details.
+See :external+snap:ref:`explanation-interfaces-all-about-interfaces` for details.

--- a/docs/explanation/snap-configurations.rst
+++ b/docs/explanation/snap-configurations.rst
@@ -3,9 +3,9 @@
 Snap configurations
 ===================
 
-Snaps can provide `configurable options
-<https://snapcraft.io/docs/configuration-in-snaps>`_ so that the user can change
-behavior at runtime.
+Snaps can provide :external+snap:ref:`configurable options
+<how-to-guides-work-with-snaps-configure-snaps>` so that the user can change behavior at
+runtime.
 
 
 Implementation in a snap
@@ -35,9 +35,9 @@ configuration files.
 Interpreting options
 --------------------
 
-Internally, snaps view and change their configuration with `snapctl
-<https://snapcraft.io/docs/how-to-guides/snap-development/use-snapctl/>`__ and its
-``get``, ``set``, and ``unset`` arguments.
+Internally, snaps view and change their configuration with :external+snap:ref:`snapctl
+<how-to-guides-manage-snaps-use-snapctl>` and its ``get``, ``set``, and ``unset``
+arguments.
 
 The snapctl command works anywhere within the snap context, during execution of your
 apps and services, and in all the snap's hooks.
@@ -75,11 +75,12 @@ Setting these values explicitly is preferred over using implicit defaults in the
 because this way, users can easily discover which configuration options your snap
 supports.
 
-On Ubuntu Core, a device's `gadget snap <https://snapcraft.io/docs/the-gadget-snap>`_
-can share default configuration options with the snaps listed in its ``gadget.yaml``
-file. These options are shared when a snap is first installed using either the
-:ref:`default-configure hook <how-to-add-a-snap-configuration-default-configure-hook>`,
-which is run before services are started, or with the :ref:`configure hook
+On Ubuntu Core, a device's :external+snap:ref:`gadget snap
+<reference-development-yaml-schemas-the-gadget-snap>` can share default configuration
+options with the snaps listed in its ``gadget.yaml`` file. These options are shared when
+a snap is first installed using either the :ref:`default-configure hook
+<how-to-add-a-snap-configuration-default-configure-hook>`, which is run before services
+are started, or with the :ref:`configure hook
 <how-to-add-a-snap-configuration-configure-hook>`, which runs after services are
 started.
 

--- a/docs/how-to/change-bases/change-from-core18-to-core20.rst
+++ b/docs/how-to/change-bases/change-from-core18-to-core20.rst
@@ -155,10 +155,10 @@ Audio interfaces
 ----------------
 
 For applications which play or record audio, the interface names have changed.
-Previously the `pulseaudio <https://snapcraft.io/docs/pulseaudio-interface>`_ interface
-was used for both playback and recording of audio. This has been replaced by
-`audio-playback <https://snapcraft.io/docs/audio-playback-interface>`_ and
-`audio-record <https://snapcraft.io/docs/audio-record-interface>`_:
+Previously the :external+snap:ref:`interfaces-pulseaudio-interface` was used for both
+playback and recording of audio. This has been replaced by
+:external+snap:ref:`interfaces-audio-playback-interface` and
+:external+snap:ref:`interfaces-audio-record-interface`:
 
 .. code-block:: diff
     :caption: snapcraft.yaml of Xonotic

--- a/docs/how-to/crafting/configure-package-information.rst
+++ b/docs/how-to/crafting/configure-package-information.rst
@@ -251,8 +251,8 @@ First, in the main app's definition, set the ``desktop`` key to the path of the
 ``.desktop`` file. The key accepts a path relative to the ``prime`` directory during the
 prime step of the build, so it must match the file's location during that step.
 
-While you're still in the main app, connect the `desktop interface
-<https://snapcraft.io/docs/desktop-interface>`_.
+While you're still in the main app, connect the
+:external+snap:ref:`interfaces-desktop-interface`.
 
 Lastly, make sure that the ``Icon`` path in the desktop entry is available in the
 ``prime`` folder. During build, Snapcraft will attempt to automatically resolve the

--- a/docs/how-to/crafting/enable-classic-confinement.rst
+++ b/docs/how-to/crafting/enable-classic-confinement.rst
@@ -4,7 +4,7 @@ Enable classic confinement
 ==========================
 
 When a snap needs system resources beyond what strict confinement and the available
-`interfaces <https://snapcraft.io/docs/supported-interfaces>`_ can provide, it needs
+:external+snap:ref:`interfaces <ref-index_interfaces>` can provide, it needs
 :ref:`classic confinement <explanation-classic-confinement>`.
 
 This page provides guidance on how to enable classic confinement, as well as example
@@ -41,9 +41,9 @@ A classically-confined snap requires approval from the Store team before you can
 distribute it on the Snap Store. Obtaining approval takes on average three to five
 business days.
 
-`Submit your snap for review
-<https://snapcraft.io/docs/reviewing-classic-confinement-snaps>`_ to get approval for
-classic confinement.
+:external+snap:ref:`Submit your snap for review
+<interfaces-reviewing-classic-confinement-snaps>` to get approval for classic
+confinement.
 
 
 .. _how-to-enable-classic-confinement-identify-problems-linters:

--- a/docs/how-to/crafting/specify-a-base.rst
+++ b/docs/how-to/crafting/specify-a-base.rst
@@ -80,9 +80,8 @@ require re-downloading Snapcraft.
 Parallel installs
 ^^^^^^^^^^^^^^^^^
 
-Multiple instances of Snapcraft can be installed via ``snapd``'s experimental
-parallel install feature. See the `Parallel installs`_ documentation for
-details.
+Multiple instances of Snapcraft can be installed with the experimental
+:external+snap:ref:`parallel installs <interfaces-parallel-installs>` feature in SnapD.
 
 .. code-block:: bash
 
@@ -166,6 +165,4 @@ This snippet will build a bare base snap inside an Ubuntu 26.04 build
 environment.
 
 
-.. _`Snapcraft and ESM`: https://snapcraft.io/docs/snapcraft-esm
 .. _`Snapcraft rocks`: https://github.com/canonical/snapcraft-rocks
-.. _`parallel installs`: https://snapcraft.io/docs/parallel-installs

--- a/docs/how-to/debugging/debug-a-snap.rst
+++ b/docs/how-to/debugging/debug-a-snap.rst
@@ -66,7 +66,7 @@ app when the snap is installed on a device.
 Interfaces
 ~~~~~~~~~~
 
-The `list of interfaces <https://snapcraft.io/docs/supported-interfaces>`_ details the
+:external+snap:ref:`ref-index_interfaces` in the snap documentation details the
 capabilities that each brings. When an interface is omitted, this may result in the app
 misbehaving. Consult the list to identify the necessary interfaces required by their
 app.
@@ -262,6 +262,6 @@ Debug with snapd
 ----------------
 
 The ``snap`` command itself has many diagnostic features that can help with debugging
-runtime and configuration errors. `Debugging snaps
-<https://snapcraft.io/docs/debug-snaps>`_ in the snapd documentation covers how and when
-to use them.
+runtime and configuration errors.
+:external+snap:ref:`how-to-guides-fix-common-issues-debug-snaps` in the snapd
+documentation covers how and when to use them.

--- a/docs/how-to/debugging/debug-with-gdb.rst
+++ b/docs/how-to/debugging/debug-with-gdb.rst
@@ -173,7 +173,6 @@ you would a normally built app.
 .. image:: https://assets.ubuntu.com/v1/430a49e2-vscode_03.png
    :alt: GDB output in the Debug Console in VS Code.
 
-.. _confined environment: https://snapcraft.io/docs/snap-confinement
 .. _GNU Debugger: https://sourceware.org/gdb
 .. _gdbserver: https://sourceware.org/gdb/current/onlinedocs/gdb.html/Server.html
 .. _GDB documentation: https://sourceware.org/gdb/current/onlinedocs/gdb/

--- a/docs/how-to/extensions/use-the-env-injector-extension.rst
+++ b/docs/how-to/extensions/use-the-env-injector-extension.rst
@@ -53,9 +53,9 @@ Set an environment variable
 ---------------------------
 
 When an app in a snap has behavior bound to an environment variable, the user can set it
-either through the `snap's configuration
-<https://snapcraft.io/docs/configuration-in-snaps>`_ or by reading an environment
-(``.env``) file.
+either through the :external+snap:ref:`snap's configuration
+<how-to-guides-work-with-snaps-configure-snaps>` or by reading an environment (``.env``)
+file.
 
 Environment variables are applied to apps in one of two ways:
 
@@ -105,7 +105,7 @@ The user can pass environment variables in ``.env`` files to the snap with the `
 set`` command.
 
 If a snap is confined, its file system needs access to the file, either by storing the
-file in its `writable area <https://snapcraft.io/docs/data-locations>`_ or through a
+file in its :external+snap:ref:`writable area <interfaces-data-locations>` or through a
 file interface.
 
 For a simple example, to globally export the contents of an environment file stored in

--- a/docs/how-to/integrations/craft-an-ros-2-app.rst
+++ b/docs/how-to/integrations/craft-an-ros-2-app.rst
@@ -226,9 +226,9 @@ Share content between ROS 2 snaps
 ---------------------------------
 
 The core20, core22 and core24 bases also offer the option to build your ROS snap using
-the `content-sharing interface <https://snapcraft.io/docs/content-interface>`_. It
-shares the ROS 2 content packages across multiple snaps, saving space and ensuring
-package consistency throughout your snap build environment.
+the :external+snap:ref:`interfaces-content-interface`. It shares the ROS 2 content
+packages across multiple snaps, saving space and ensuring package consistency throughout
+your snap build environment.
 
 You can find more information in `ROS architectures with snaps
 <https://ubuntu.com/robotics/docs/ros-architectures-with-snaps>`_ in the Canonical ROS

--- a/docs/how-to/publishing/get-snap-metrics.rst
+++ b/docs/how-to/publishing/get-snap-metrics.rst
@@ -120,7 +120,7 @@ Troubleshoot access to metric data
 ----------------------------------
 
 The `Snap Store metrics API
-<https://dashboard.snapcraft.io/docs/reference/v1/snap.html#fetch-metrics-for-snaps>`_,
+<https://dashboard.snapcraft.io/docs/reference/v1/snap.html#fetch-metrics-for-snaps>`__,
 called by the ``snapcraft metrics`` command, requires your account to have the
 package_metrics permission.
 

--- a/docs/how-to/select-a-build-provider.rst
+++ b/docs/how-to/select-a-build-provider.rst
@@ -65,8 +65,7 @@ For core20, Multipass is the default provider on all platforms.
 Select through the snap configuration
 -------------------------------------
 
-The snap configuration method mentioned in the previous sections is a `feature
-of snapd <https://snapcraft.io/docs/configuration-in-snaps>`_.
+The snap configuration method mentioned in the previous sections is a feature of snaps.
 
 Like most snaps, Snapcraft isn't installed with any default configuration
 values. As a result, you won't be able to check the provider programmatically

--- a/docs/how-to/set-up-snapcraft.rst
+++ b/docs/how-to/set-up-snapcraft.rst
@@ -170,10 +170,9 @@ note of the value in the channel column.
 
     snap info snapcraft
 
-Install a new instance of Snapcraft with the `instance key naming
-<https://snapcraft.io/docs/explanation/how-snaps-work/parallel-installs/>`__ syntax,
-replacing ``<instance>`` with whichever name is appropriate for the instance, and
-``<channel>`` with the target channel and track:
+Install a new instance of Snapcraft with the :external+snap:ref:`instance key naming
+<interfaces-parallel-installs>` syntax, replacing ``<instance>`` with whichever name is
+appropriate for the instance, and ``<channel>`` with the target channel and track:
 
 .. code:: bash
 

--- a/docs/reference/bases.rst
+++ b/docs/reference/bases.rst
@@ -102,7 +102,6 @@ Kernel snaps
 See :ref:`How to build a kernel snap<kernel-snap-how-to>` for details on how to
 use ``build-base`` for kernel snaps.
 
-.. _`Snapcraft and ESM`: https://snapcraft.io/docs/snapcraft-esm
 .. _`Ubuntu 16.04 ESM`: https://releases.ubuntu.com/16.04/
 .. _`Ubuntu 18.04 ESM`: https://releases.ubuntu.com/18.04/
 .. _`Ubuntu 20.04 LTS`: https://releases.ubuntu.com/20.04/

--- a/docs/reference/channels.rst
+++ b/docs/reference/channels.rst
@@ -28,12 +28,12 @@ The *track* represents the highest level of organization for the snap's
 release. Typically, it signifies a major release. Authors can use tracks to
 maintain different major versions of their software.
 
-All snaps have one default track, called *latest*. Most operations and commands
-within Snapcraft and the snap ecosystem assume this track, unless otherwise
-specified. If a snap has need for other tracks, they must be vetted and granted
-on a snap-by-snap basis by the Snap Store team. The process for requesting a
-track is outlined in `Process for aliases, auto-connections and tracks
-<https://snapcraft.io/docs/process-for-aliases-auto-connections-and-tracks>`_.
+All snaps have one default track, called *latest*. Most operations and commands within
+Snapcraft and the snap ecosystem assume this track, unless otherwise specified. If a
+snap has need for other tracks, they must be vetted and granted on a snap-by-snap basis
+by the Snap Store team. The process for requesting a track is outlined in
+:external+snap:ref:`Process for aliases, auto-connections and tracks
+<interfaces-process-for-aliases-auto-connections-and-tracks>` in the snap documentation.
 
 The release semantics for a track is at the snap author's discretion. A track
 could, for examples, encompass minor updates, major updates, or long-term

--- a/docs/reference/channels.rst
+++ b/docs/reference/channels.rst
@@ -32,8 +32,8 @@ All snaps have one default track, called *latest*. Most operations and commands 
 Snapcraft and the snap ecosystem assume this track, unless otherwise specified. If a
 snap has need for other tracks, they must be vetted and granted on a snap-by-snap basis
 by the Snap Store team. The process for requesting a track is outlined in
-:external+snap:ref:`Process for aliases, auto-connections and tracks
-<interfaces-process-for-aliases-auto-connections-and-tracks>` in the snap documentation.
+:external+snap:ref:`interfaces-process-for-aliases-auto-connections-and-tracks` in the
+snap documentation.
 
 The release semantics for a track is at the snap author's discretion. A track
 could, for examples, encompass minor updates, major updates, or long-term

--- a/docs/reference/extensions/env-injector-extension.rst
+++ b/docs/reference/extensions/env-injector-extension.rst
@@ -7,8 +7,9 @@ The env-injector extension, referred to internally as ``env-injector``, provides
 interface for altering snap behavior with user-defined environment variables.
 
 When you add the extension to individual apps inside a snap, you open the way for the
-user to `configure the snap <https://snapcraft.io/docs/configuration-in-snaps>`_ or
-affect its behavior with environment variables.
+user to :external+snap:ref:`configure the snap
+<how-to-guides-work-with-snaps-configure-snaps>` or affect its behavior with environment
+variables.
 
 
 How it works
@@ -55,7 +56,7 @@ Runtime process
 When the snap runs, for each app that uses the extension, the exporter program:
 
 1. Runs before the app is executed.
-2. Makes a request to the `snapd API <https://snapcraft.io/docs/using-the-api>`_
+2. Makes a request to the :external+snap:doc:`reference/development/snapd-rest-api`
    through the snapd Unix socket.
 3. Reads the available environment variables or paths to the ``.env`` files.
 4. Translates the snap options into environment variables.

--- a/docs/reference/extensions/ros-1-content-extensions.rst
+++ b/docs/reference/extensions/ros-1-content-extensions.rst
@@ -4,8 +4,8 @@ ROS 1 Content extensions
 ========================
 
 The ROS 1 Content extensions comprise the main :ref:`reference-ros-1-extension`, plus
-additional settings to enable `content sharing
-<https://snapcraft.io/docs/content-interface>`_.
+additional settings to enable :external+snap:ref:`content sharing
+<interfaces-content-interface>`.
 
 These extensions are split across content types, and are declared with the format
 ``ros1-noetic-<metapackage>``. The available extensions are:
@@ -21,8 +21,8 @@ Included interface connections
 ------------------------------
 
 The most important modification the content extension makes to the project file is to
-connect the `content plug <https://snapcraft.io/docs/content-interface>`_ which mounts
-the provider snap content at ``$SNAP/opt/ros/underlay_ws`` and defines a default
+connect the :external+snap:ref:`content plug <interfaces-content-interface>` which
+mounts the provider snap content at ``$SNAP/opt/ros/underlay_ws`` and defines a default
 provider.
 
 

--- a/docs/reference/extensions/ros-2-content-extensions.rst
+++ b/docs/reference/extensions/ros-2-content-extensions.rst
@@ -4,7 +4,7 @@ ROS 2 Content extensions
 ========================
 
 The ROS 2 Content extensions comprise the main ROS 2 extensions, plus additional
-settings to enable `content sharing <https://snapcraft.io/docs/content-interface>`_.
+settings to enable :external+snap:ref:`content sharing <interfaces-content-interface>`.
 
 These extensions are split across ROS 2 versions and content types, and are declared
 with the format ``ros2-<version>-<metapackage>``. The available extensions are:
@@ -36,8 +36,8 @@ Included interface connections
 ------------------------------
 
 The most important modification the content extensions make to the project file is to
-connect the `content plug <https://snapcraft.io/docs/content-interface>`_ which mounts
-the provider snap content at ``$SNAP/opt/ros/underlay_ws`` and defines a default
+connect the :external+snap:ref:`content plug <interfaces-content-interface>` which
+mounts the provider snap content at ``$SNAP/opt/ros/underlay_ws`` and defines a default
 provider.
 
 

--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -24,8 +24,9 @@ after the hook finishes executing.
 
 This allows changes to be rolled back if errors occur during the execution of a hook.
 This happens if a non-zero value is returned with either the configure or
-default-configure hooks or if an error occurs with any hook involved with
-an `interface auto-connection <https://snapcraft.io/docs/auto-connection-mechanism>`_.
+default-configure hooks or if an error occurs with any hook involved with an
+:external+snap:ref:`interface auto-connection
+<explanation-interfaces-interface-auto-connection>`.
 
 Environment
 -----------
@@ -87,11 +88,11 @@ part that adds a configure hook using the :ref:`craft_parts_dump_plugin` and the
 Accessing resources
 -------------------
 
-If a hook requires access to system resources outside of a snap’s confined environment,
+If a hook requires access to system resources outside of a snap's confined environment,
 it needs to use :ref:`interfaces <explanation-interfaces>` to access those resources.
 
-The following example registers an install hook making use of the `network
-<https://snapcraft.io/docs/network-interface>`_ interface:
+The following example registers an install hook making use of the
+:external+snap:ref:`interfaces-network-interface`:
 
 .. code-block:: yaml
     :caption: snapcraft.yaml

--- a/docs/reference/layouts.rst
+++ b/docs/reference/layouts.rst
@@ -42,8 +42,9 @@ Requirements
 
 Layouts and their definitions must satisfy the following requirements.
 
-**Strictly-confined snaps**. Layouts only work with `strictly-confined
-<https://snapcraft.io/docs/snap-confinement>`_ snaps, and not with classic confinement.
+**Strictly-confined snaps**. Layouts only work with
+:external+snap:ref:`strictly-confined <explanation-security-snap-confinement>` snaps,
+and not classically-confined snaps.
 
 **Disallowed target paths**. The target path in a layout definition can't be:
 

--- a/docs/reference/project-file/anatomy-of-snapcraft-yaml.rst
+++ b/docs/reference/project-file/anatomy-of-snapcraft-yaml.rst
@@ -90,11 +90,10 @@ uses.
 Confinement
 ^^^^^^^^^^^
 
-Security confinement distinguishes snaps from software distributed using the
-traditional repository methods. `Confinement
-<https://snapcraft.io/docs/snap-confinement>`_ allows for a high level of
-isolation and security, and prevents snaps from being affected by underlying
-system changes, snaps affecting each other, or snaps affecting the host.
+Security confinement distinguishes snaps from software distributed using the traditional
+repository methods. :external+snap:ref:`explanation-security-snap-confinement` provides
+a high level of isolation and security, and prevents snaps from being affected by
+underlying system changes, snaps affecting each other, or snaps affecting the host.
 
 The ``confinement`` key describes what type of access the snap's apps will have
 once installed on the host. Confinement levels can be treated as filters that
@@ -121,12 +120,12 @@ There are three confinement levels:
   as a stop-gap measure to enable developers to publish apps that need more
   access than the current set of permissions allow.
 
-  This confinement should be used only when required for functionality, as its
-  lack of restrictions is a security risk. Before a snap can be published with
-  classic confinement, it must be approved by the Snap Store team according to
-  a `candidate review process
-  <https://forum.snapcraft.io/t/process-for-reviewing-classic-confinement-snaps/1460>`_.
-  Snaps may be rejected if they don't meet the necessary requirements.
+  This confinement should be used only when required for functionality, as its lack of
+  restrictions is a security risk. Before a snap can be published with classic
+  confinement, it must be approved by the Snap Store team according to a
+  :external+snap:ref:`candidate review process
+  <interfaces-reviewing-classic-confinement-snaps>`. Snaps may be rejected if they
+  don't meet the necessary requirements.
 
 Parts
 ~~~~~

--- a/docs/reference/snapshots.rst
+++ b/docs/reference/snapshots.rst
@@ -3,10 +3,10 @@
 Snapshots
 =========
 
-A snap's system and user data can be excluded from `snapshots
-<https://snapcraft.io/docs/snapshots>`_ by specifying exclusion patterns in an optional
-metadata file called ``snapshots.yaml``. Such exclusions can be used to control snapshot
-content and size.
+A snap's system and user data can be excluded from :external+snap:ref:`snapshots
+<how-to-guides-manage-snaps-create-data-snapshots>` by specifying exclusion patterns in
+an optional metadata file called ``snapshots.yaml``. Such exclusions can be used to
+control snapshot content and size.
 
 .. important::
 

--- a/docs/reference/system-requirements.rst
+++ b/docs/reference/system-requirements.rst
@@ -29,8 +29,8 @@ Platform requirements
     - Version
     - Software requirements
   * - GNU/Linux
-    - Popular distributions that ship with systemd and are `compatible with
-      snapd <https://snapcraft.io/docs/installing-snapd>`_
+    - Popular distributions that ship with systemd and are
+      :external+snap:ref:`compatible with snapd <tutorials-install-the-daemon-index>`
     - systemd
 
       snapd 2.44.3 or higher

--- a/docs/release-notes/snapcraft-8-10.rst
+++ b/docs/release-notes/snapcraft-8-10.rst
@@ -75,17 +75,17 @@ it should be done with the ``build-environment`` key instead of ``cmake-paramete
 Summaries for confdb schemas
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``edit-confdb-schema`` command now supports a top-level
-``summary`` key and a ``summary`` key in each view of a `confdb schema
-<https://snapcraft.io/docs/configure-with-confdb>`_.
+The ``edit-confdb-schema`` command now supports a top-level ``summary`` key and a
+``summary`` key in each view of a :external+snap:ref:`confdb schema
+<how-to-guides-manage-snaps-configure-snaps-with-confdb>`.
 
 
 Validation set sequence warning
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If a user forgets to increment the sequence when editing a `validation set
-<https://snapcraft.io/docs/validation-sets>`_, it can prevent snaps from being able to
-revert to a valid state.
+If a user forgets to increment the sequence when editing a
+:external+snap:ref:`validation set <explanation-how-snaps-work-validation-sets>`, it can
+prevent snaps from being able to revert to a valid state.
 
 The :ref:`ref_commands_edit-validation-sets` command will now warn the user if the
 sequence hasn't been incremented and prompt them to re-edit the set before submitting

--- a/docs/release-notes/snapcraft-8-7.rst
+++ b/docs/release-notes/snapcraft-8-7.rst
@@ -42,9 +42,10 @@ Remote builds can now use the ``--build-for`` option to filter entries in an
 Support for confdbs
 ~~~~~~~~~~~~~~~~~~~
 
-A `confdb schema <https://snapcraft.io/docs/configure-with-confdb>`_ defines the
-configuration of Linux systems, including storage, access permission, granularity,
-and sharing between snaps.
+A :external+snap:ref:`confdb schema
+<how-to-guides-manage-snaps-configure-snaps-with-confdb>` defines the configuration of
+Linux systems, including storage, access permission, granularity, and sharing between
+snaps.
 
 Snapcraft now supports listing and editing ``confdbs`` with the commands
 ``list-confdbs`` and ``edit-confdbs``. These new commands replace the previous

--- a/docs/release-notes/snapcraft-8-9.rst
+++ b/docs/release-notes/snapcraft-8-9.rst
@@ -49,7 +49,7 @@ Documentation migration and redesign
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Previously, the main source of Snapcraft documentation was hosted on a Discourse
-instance at `snapcraft.io <http://snapcraft.io/docs>`_.
+instance at `snapcraft.io <http://snapcraft.io/docs>`__.
 
 With Snapcraft 8.9, the essential documentation was shifted to ReadTheDocs and is now
 hosted inside the Snapcraft repository. In the process, much of the documentation was
@@ -108,9 +108,10 @@ The following changes are incompatible with previous versions of Snapcraft.
 Renaming of confdb schema commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A `confdb schema <https://snapcraft.io/docs/configure-with-confdb>`_ defines the
-configuration of Linux systems, including storage, access permission, granularity,
-and sharing between snaps.
+A :external+snap:ref:`confdb schema
+<how-to-guides-manage-snaps-configure-snaps-with-confdb>` defines the configuration of
+Linux systems, including storage, access permission, granularity, and sharing between
+snaps.
 
 The existing confdb schema commands have been renamed as follows:
 

--- a/snapcraft/extensions/gnome.py
+++ b/snapcraft/extensions/gnome.py
@@ -63,12 +63,12 @@ class GNOME(GPUExtension):
     For easier desktop integration, it also configures each application
     entry with these additional plugs:
 
-    - desktop (https://snapcraft.io/docs/desktop-interface)
-    - desktop-legacy (https://snapcraft.io/docs/desktop-legacy-interface)
-    - gsettings (https://snapcraft.io/docs/gsettings-interface)
-    - opengl (https://snapcraft.io/docs/opengl-interface)
-    - wayland (https://snapcraft.io/docs/wayland-interface)
-    - x11 (https://snapcraft.io/docs/x11-interface)
+    - desktop (https://snapcraft.io/docs/reference/interfaces/desktop-interface)
+    - desktop-legacy (https://snapcraft.io/docs/reference/interfaces/desktop-legacy-interface)
+    - gsettings (https://snapcraft.io/docs/reference/interfaces/gsettings-interface)
+    - opengl (https://snapcraft.io/docs/reference/interfaces/opengl-interface)
+    - wayland (https://snapcraft.io/docs/reference/interfaces/wayland-interface)
+    - x11 (https://snapcraft.io/docs/reference/interfaces/x11-interface)
     """
 
     @staticmethod

--- a/snapcraft/extensions/kde_neon.py
+++ b/snapcraft/extensions/kde_neon.py
@@ -68,11 +68,11 @@ class KDENeon(GPUExtension):
     entry with these additional plugs:
 
     \b
-    - desktop (https://snapcraft.io/docs/desktop-interface)
-    - desktop-legacy (https://snapcraft.io/docs/desktop-legacy-interface)
-    - opengl (https://snapcraft.io/docs/opengl-interface)
-    - wayland (https://snapcraft.io/docs/wayland-interface)
-    - x11 (https://snapcraft.io/docs/x11-interface)
+    - desktop (https://snapcraft.io/docs/reference/interfaces/desktop-interface)
+    - desktop-legacy (https://snapcraft.io/docs/reference/interfaces/desktop-legacy-interface)
+    - opengl (https://snapcraft.io/docs/reference/interfaces/opengl-interface)
+    - wayland (https://snapcraft.io/docs/reference/interfaces/wayland-interface)
+    - x11 (https://snapcraft.io/docs/reference/interfaces/x11-interface)
     """
 
     @staticmethod

--- a/snapcraft/extensions/kde_neon_6.py
+++ b/snapcraft/extensions/kde_neon_6.py
@@ -73,15 +73,15 @@ class KDENeon6(GPUExtension):
     entry with these additional plugs:
 
     \b
-    - desktop (https://snapcraft.io/docs/desktop-interface)
-    - desktop-legacy (https://snapcraft.io/docs/desktop-legacy-interface)
-    - opengl (https://snapcraft.io/docs/opengl-interface)
-    - wayland (https://snapcraft.io/docs/wayland-interface)
-    - x11 (https://snapcraft.io/docs/x11-interface)
-    - audio-playback (https://snapcraft.io/docs/audio-playback-interface)
-    - unity7 (https://snapcraft.io/docs/unity7-interface)
-    - network https://snapcraft.io/docs/network-interface)
-    - network-bind (https://snapcraft.io/docs/network-bind-interface)
+    - desktop (https://snapcraft.io/docs/reference/interfaces/desktop-interface)
+    - desktop-legacy (https://snapcraft.io/docs/reference/interfaces/desktop-legacy-interface)
+    - opengl (https://snapcraft.io/docs/reference/interfaces/opengl-interface)
+    - wayland (https://snapcraft.io/docs/reference/interfaces/wayland-interface)
+    - x11 (https://snapcraft.io/docs/reference/interfaces/x11-interface)
+    - audio-playback (https://snapcraft.io/docs/reference/interfaces/audio-playback-interface)
+    - unity7 (https://snapcraft.io/docs/reference/interfaces/unity7-interface)
+    - network (https://snapcraft.io/docs/reference/interfaces/network-interface)
+    - network-bind (https://snapcraft.io/docs/reference/interfaces/network-bind-interface)
     """
 
     @staticmethod

--- a/snapcraft/extensions/kde_neon_qt6.py
+++ b/snapcraft/extensions/kde_neon_qt6.py
@@ -65,15 +65,15 @@ class KDENeonQt6(GPUExtension):
     entry with these additional plugs:
 
     \b
-    - desktop (https://snapcraft.io/docs/desktop-interface)
-    - desktop-legacy (https://snapcraft.io/docs/desktop-legacy-interface)
-    - opengl (https://snapcraft.io/docs/opengl-interface)
-    - wayland (https://snapcraft.io/docs/wayland-interface)
-    - x11 (https://snapcraft.io/docs/x11-interface)
-    - audio-playback (https://snapcraft.io/docs/audio-playback-interface)
-    - unity7 (https://snapcraft.io/docs/unity7-interface)
-    - network https://snapcraft.io/docs/network-interface)
-    - network-bind (https://snapcraft.io/docs/network-bind-interface)
+    - desktop (https://snapcraft.io/docs/reference/interfaces/desktop-interface)
+    - desktop-legacy (https://snapcraft.io/docs/reference/interfaces/desktop-legacy-interface)
+    - opengl (https://snapcraft.io/docs/reference/interfaces/opengl-interface)
+    - wayland (https://snapcraft.io/docs/reference/interfaces/wayland-interface)
+    - x11 (https://snapcraft.io/docs/reference/interfaces/x11-interface)
+    - audio-playback (https://snapcraft.io/docs/reference/interfaces/audio-playback-interface)
+    - unity7 (https://snapcraft.io/docs/reference/interfaces/unity7-interface)
+    - network (https://snapcraft.io/docs/reference/interfaces/network-interface)
+    - network-bind (https://snapcraft.io/docs/reference/interfaces/network-bind-interface)
     """
 
     @staticmethod

--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -72,7 +72,8 @@ class SnapApp(SnapcraftMetadata):
     https://snapcraft.io/docs/reference/development/yaml-schemas/the-snap-format/ for
     details.
 
-    TODO: implement desktop (CRAFT-804) TODO: implement extensions (CRAFT-805)
+    TODO: implement desktop (CRAFT-804)
+    TODO: implement extensions (CRAFT-805)
     """
 
     command: str

--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -69,10 +69,10 @@ class SnapApp(SnapcraftMetadata):
     """Snap.yaml app entry.
 
     This is currently a partial implementation, see
-    https://snapcraft.io/docs/snap-format for details.
+    https://snapcraft.io/docs/reference/development/yaml-schemas/the-snap-format/ for
+    details.
 
-    TODO: implement desktop (CRAFT-804)
-    TODO: implement extensions (CRAFT-805)
+    TODO: implement desktop (CRAFT-804) TODO: implement extensions (CRAFT-805)
     """
 
     command: str
@@ -243,7 +243,8 @@ class SnapMetadata(SnapcraftMetadata):
     """The snap.yaml model.
 
     This is currently a partial implementation, see
-    https://snapcraft.io/docs/snap-format for details.
+    https://snapcraft.io/docs/reference/development/yaml-schemas/the-snap-format/ for
+    details.
 
     TODO: should platforms replace architectures for core24?
     """

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -810,7 +810,7 @@ class App(models.CraftBaseModel):
 
     Slots are used to define what code and data can be shared with other snaps.
 
-    See :external+snap:ref:`interfaces-content-interface` in the snap documenation for
+    See :external+snap:ref:`interfaces-content-interface` in the snap documentation for
     more information about plugs and slots.
     """
 
@@ -821,7 +821,7 @@ class App(models.CraftBaseModel):
     )
     """The list of interfaces that the app can connect to.
 
-    See :external+snap:ref:`interfaces-content-interface` in the snap documenation for
+    See :external+snap:ref:`interfaces-content-interface` in the snap documentation for
     more information about plugs and slots.
     """
 

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -446,9 +446,9 @@ class App(models.CraftBaseModel):
     in the ``Exec=`` line in the ``.desktop`` file when the desktop environment is
     started.
 
-    See `The snap format
-    <https://snapcraft.io/docs/reference/development/yaml-schemas/the-snap-format>`__ in
-    the snap docs for an example of both the desktop file and the ``Exec`` file entry.
+    See :external+snap:ref:`reference-development-yaml-schemas-the-snap-format` in the
+    snap documentation for an example of both the desktop file and the ``Exec`` file
+    entry.
     """
 
     common_id: str | None = pydantic.Field(
@@ -793,10 +793,9 @@ class App(models.CraftBaseModel):
             service. This will start the service too.
         * - ``disable``
           - The service is not automatically started. Instead, the service will be
-            started with `snapctl
-            <https://snapcraft.io/docs/how-to-guides/snap-development/use-snapctl/>`__.
-            and another management agent, which is most commonly a :ref:`hooks
-            <reference-hooks>`.
+            started with :external+snap:ref:`snapctl
+            <how-to-guides-manage-snaps-use-snapctl>` and another management agent,
+            which is most commonly a :ref:`hooks <reference-hooks>`.
 
     """
 
@@ -807,13 +806,12 @@ class App(models.CraftBaseModel):
     )
     """The list of slots that the app provides.
 
-    Slot connections are only made when the snap is running in ``strict``
-    confinement.
+    Slot connections are only made when the snap is running in ``strict`` confinement.
 
     Slots are used to define what code and data can be shared with other snaps.
 
-    See the `content interface <https://snapcraft.io/docs/content-interface>`_
-    for more information about plugs and slots.
+    See :external+snap:ref:`interfaces-content-interface>` in the snap documenation for
+    more information about plugs and slots.
     """
 
     plugs: UniqueList[str] | None = pydantic.Field(
@@ -823,8 +821,8 @@ class App(models.CraftBaseModel):
     )
     """The list of interfaces that the app can connect to.
 
-    See the `content interface <https://snapcraft.io/docs/content-interface>`_
-    for more information about plugs and slots.
+    See :external+snap:ref:`interfaces-content-interface>` in the snap documenation for
+    more information about plugs and slots.
     """
 
     aliases: UniqueList[str] | None = pydantic.Field(
@@ -834,8 +832,8 @@ class App(models.CraftBaseModel):
     )
     """The aliases that can be used to run the app.
 
-    See `Commands and aliases <https://snapcraft.io/docs/commands-and-aliases>`_
-    for more information.
+    See :external+snap:ref:`how-to-guides-work-with-snaps-apps-and-aliases` in the snap
+    documentation for more information.
     """
 
     environment: dict[str, str] | None = pydantic.Field(
@@ -932,16 +930,15 @@ class App(models.CraftBaseModel):
     )
     """The attributes to pass to the snap's metadata file for the app.
 
-    These attributes are passed to the ``snap.yaml`` file without validation from Snapcraft.
-    This is useful for early testing of a new feature in snapd that isn't supported yet
-    by Snapcraft.
+    These attributes are passed to the ``snap.yaml`` file without validation from
+    Snapcraft. This is useful for early testing of a new feature in snapd that isn't
+    supported yet by Snapcraft.
 
     To pass a value for the entire project, see the top-level :ref:`passthrough key
     <Project.passthrough>`.
 
-    See `Using development features in Snapcraft
-    <https://snapcraft.io/docs/using-in-development-features>`_ for more
-    details.
+    :external+snap:ref:`interfaces-using-in-development-features` in the snap
+    documentation offers more guidance.
     """
 
     extensions: UniqueList[str] | None = pydantic.Field(
@@ -1063,8 +1060,8 @@ class Hook(models.CraftBaseModel):
     )
     """The list of interfaces that the hook can connect to.
 
-    See the `content interface <https://snapcraft.io/docs/content-interface>`_ for more
-    information about plugs and slots.
+    See :external+snap:ref:`interfaces-content-interface` in the snap documentation for
+    more information about plugs and slots.
     """
 
     passthrough: dict[str, Any] | None = pydantic.Field(
@@ -1081,8 +1078,8 @@ class Hook(models.CraftBaseModel):
     To pass a value for the entire project, see the top-level :ref:`passthrough key
     <Project.passthrough>`.
 
-    See `Using development features in Snapcraft
-    <https://snapcraft.io/docs/using-in-development-features>`_ for more details.
+    :external+snap:ref:`interfaces-using-in-development-features` in the snap
+    documentation offers more guidance.
     """
 
     @pydantic.field_validator("command_chain")
@@ -1146,8 +1143,8 @@ class ContentPlug(models.CraftBaseModel):
     )
     """The name of the interface.
 
-    See `Supported interfaces <https://snapcraft.io/docs/supported-interfaces>`_ for a
-    list of supported interfaces.
+    See :external+snap:ref:`ref-index_interfaces` in the snap documentation for a list
+    of supported interfaces.
 
     When using the content interface, this should be set to ``content``.
     """
@@ -1158,8 +1155,9 @@ class ContentPlug(models.CraftBaseModel):
     )
     """The path to where the producer's files will be available in the snap.
 
-    This is only needed when using the content interface. See the `Content
-    interface <https://snapcraft.io/docs/content-interface>`_ for more information.
+    This is only needed when using the content interface. See
+    :external+snap:ref:`interfaces-content-interface` in the snap documentation for more
+    information.
     """
 
     default_provider: str | None = pydantic.Field(
@@ -1169,8 +1167,9 @@ class ContentPlug(models.CraftBaseModel):
     )
     """The name of the producer snap.
 
-    This is only needed when using the content interface. See the `Content interface
-    <https://snapcraft.io/docs/content-interface>`_ for more information.
+    This is only needed when using the content interface. See
+    :external+snap:ref:`interfaces-content-interface` in the snap documentation for more
+    information.
     """
 
     @pydantic.field_validator("default_provider")
@@ -1501,14 +1500,14 @@ class Project(models.Project):
     )
     """The amount of isolation the snap has from the host system.
 
-    Snap confinement determines the amount of access an application has to
-    system resources, such as files, the network, peripherals and services.
+    Snap confinement determines the amount of access an application has to system
+    resources, such as files, the network, peripherals and services.
 
-    For core22 and newer bases, confinement is a required property and has no
-    default value.
+    For core22 and newer bases, confinement is a required property and has no default
+    value.
 
-    For more information, see `Snap confinement
-    <https://snapcraft.io/docs/snap-confinement>`_.
+    For more information, see :external+snap:ref:`explanation-security-snap-confinement`
+    in the snap documentation.
 
     **Values**
 
@@ -1684,8 +1683,8 @@ class Project(models.Project):
     To pass a value for a particular app, see the :ref:`passthrough key
     <App.passthrough>` for apps.
 
-    See `Using development features in Snapcraft
-    <https://snapcraft.io/docs/using-in-development-features>`_.
+    :external+snap:ref:`interfaces-using-in-development-features` in the snap
+    documentation offers more guidance.
     """
 
     apps: dict[str, App] | None = pydantic.Field(
@@ -1793,11 +1792,11 @@ class Project(models.Project):
     )
     """The system usernames the snap can use to run daemons and services.
 
-    This is used to run daemons with the ``snap_daemon`` user defined by
-    snapd. Otherwise, this is an uncommon key.
+    This is used to run daemons with the ``snap_daemon`` user defined by snapd.
+    Otherwise, this is an uncommon key.
 
-    See `system usernames <https://snapcraft.io/docs/system-usernames>`_ for more
-    information.
+    See :external+snap:ref:`interfaces-system-usernames` in the snap documentation for
+    more information.
     """
 
     environment: dict[str, str | None] | None = pydantic.Field(

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -810,7 +810,7 @@ class App(models.CraftBaseModel):
 
     Slots are used to define what code and data can be shared with other snaps.
 
-    See :external+snap:ref:`interfaces-content-interface>` in the snap documenation for
+    See :external+snap:ref:`interfaces-content-interface` in the snap documenation for
     more information about plugs and slots.
     """
 
@@ -821,7 +821,7 @@ class App(models.CraftBaseModel):
     )
     """The list of interfaces that the app can connect to.
 
-    See :external+snap:ref:`interfaces-content-interface>` in the snap documenation for
+    See :external+snap:ref:`interfaces-content-interface` in the snap documenation for
     more information about plugs and slots.
     """
 

--- a/tests/spread/general/parallel-install/task.yaml
+++ b/tests/spread/general/parallel-install/task.yaml
@@ -11,7 +11,7 @@ prepare: |
   set_base "snap/snapcraft.yaml"
 
   # enabling parallel installs requires a reboot
-  # see https://snapcraft.io/docs/parallel-installs
+  # see https://snapcraft.io/docs/explanation/how-snaps-work/parallel-installs/
   if [[ $SPREAD_REBOOT = 0 ]]; then
     snap set system experimental.parallel-instances=true
     REBOOT


### PR DESCRIPTION
Fixes #6036:

- Connect to the snap docs with Intersphinx.
- Reformat external snap docs links into Intersphinx links.
- Update various other paths to snap docs.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
