### PR TITLE
docs: format doc version as major.minor

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,11 +29,13 @@ author = "Canonical Ltd."
 # Sidebar documentation title; best kept reasonably short
 # The full version, including alpha/beta/rc tags
 release = snapcraft.__version__
-# The commit hash in the dev release version confuses the spellchecker
 if ".post" in release:
     release = "dev"
+else:
+    major_minor = release.split(".")
+    release = f"{major_minor[0]}.{major_minor[1]}"
 
-html_title = project + " documentation"
+html_title = f"{project} {release} documentation"
 
 # Copyright string; shown at the bottom of the page
 copyright = "2015-%s, %s" % (datetime.date.today().year, author)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,10 +32,8 @@ release = snapcraft.__version__
 if ".post" in release:
     release = "dev"
 else:
-    major_minor = release.split(".")
-    release = f"{major_minor[0]}.{major_minor[1]}"
-
-html_title = f"{project} {release} documentation"
+    major, minor, *_ = release.split(".")
+    release = f"{major}.{minor}"
 
 # Copyright string; shown at the bottom of the page
 copyright = "2015-%s, %s" % (datetime.date.today().year, author)


### PR DESCRIPTION
This adopts the formatting of our minor-version-only docs.

Once this is merged, I'll move it into `hotfix/8.14`.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
