### PR TITLE
build(deps): bump craft-parts to 2.32.0

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -9,6 +9,8 @@ autoformatte(d|rs?)
 Autogen
 Automake
 Autotools
+bonjour
+Bazel
 backend
 backends
 backoff
@@ -21,6 +23,7 @@ buildd
 Bundler
 Canonical('s)?
 Charmcraft
+cameractrls
 cjk
 classpath
 CMake
@@ -40,6 +43,8 @@ Dockerfiles?
 docstrings?
 dotnet
 dvipng
+drwxr-xr-x
+drwxrwxrwx
 emacs
 FIGlet
 Filesets?
@@ -54,14 +59,17 @@ github
 GitHub
 glibc
 GPG
+gsettings
 gpu
 Gradle
 gyre
 gzip(ped)?
+hamba
 hashlib
 Hawksbill
 html
 https
+igor
 Inadyn
 ing
 Intersphinx
@@ -72,10 +80,12 @@ jemalloc
 JLink
 json
 KCalc
+kahle
 keyrings
 landscape
 lang
 lastmod
+le
 LaTeX
 latexmk
 lcm
@@ -90,11 +100,14 @@ Makefiles?
 Miniconda
 mitigations?
 mkdir
+mondo
 MSBuild
 Multipass
 mvn
+mypart
 MyST
 namespaced
+ncursesw
 nano
 Nextcloud
 Ninjemys
@@ -120,6 +133,7 @@ pymarkdown
 pytest
 QEMU
 qmake
+rackup
 Read the Docs
 readthedocs
 redeclare
@@ -130,6 +144,7 @@ Rockcraft
 rosdep
 rst
 runtimes?
+rustc
 rustup
 SCons
 scriptlets?
@@ -138,6 +153,8 @@ sed
 sequenceDiagram
 sitecustomize
 sitemapindex
+smbraille
+smscript
 snapcraftctl
 snapctl
 Sphinx
@@ -153,6 +170,7 @@ subprojects
 sudo
 SVG
 systemd
+tcp
 teardown
 tex
 texinfo
@@ -179,6 +197,7 @@ virtualized?
 VMs
 Vulkan
 WCAG
+wayland
 wethr
 whatime
 whitespace

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -207,7 +207,7 @@ exclude_patterns = [
     "common/craft-parts/reference/plugins/python_plugin.rst",
     "common/craft-parts/reference/plugins/python_v2_plugin.rst",
     "common/craft-parts/reference/plugins/uv_plugin.rst",
-    # Excluded because Snapcraft has it's own version
+    # Excluded because Snapcraft has its own version
     "common/craft-parts/reference/plugins/colcon_plugin.rst",
     # Extra non-craft-parts exclusions can be added after this comment
     # Staged files for Discourse migration

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -129,6 +129,7 @@ linkcheck_ignore = [
     r"^https://([\w-]*\.)?npmjs.org",
     r"^https://rsync.samba.org",
     r"^https://ubuntu.com",
+    r"^https://packages.ubuntu.com",
     r"^https://www.freedesktop.org/",
     r"^https://www.npmjs.com/",
     "https://matrix.to/#",
@@ -206,6 +207,8 @@ exclude_patterns = [
     "common/craft-parts/reference/plugins/python_plugin.rst",
     "common/craft-parts/reference/plugins/python_v2_plugin.rst",
     "common/craft-parts/reference/plugins/uv_plugin.rst",
+    # Excluded because Snapcraft has it's own version
+    "common/craft-parts/reference/plugins/colcon_plugin.rst",
     # Extra non-craft-parts exclusions can be added after this comment
     # Staged files for Discourse migration
     "how-to/crafting/add-a-part.rst",

--- a/docs/contribute/documentation.rst
+++ b/docs/contribute/documentation.rst
@@ -167,6 +167,7 @@ the site locally:
 If successful, the terminal prints:
 
 .. terminal::
+    :output-only:
 
     build succeeded.
     The HTML pages are in docs/_build.

--- a/docs/explanation/parts-lifecycle.rst
+++ b/docs/explanation/parts-lifecycle.rst
@@ -180,6 +180,7 @@ each step the parts are processed in alphabetical order.
 
 
 .. terminal::
+    :output-only:
 
     Pulling Alex
     Pulling Blair
@@ -211,6 +212,7 @@ Example 2 -- Order override
 
 
 .. terminal::
+    :output-only:
 
     Pulling Cam
     Pulling Alex

--- a/docs/explanation/snap-configurations.rst
+++ b/docs/explanation/snap-configurations.rst
@@ -97,9 +97,11 @@ Each configuration option can be retrieved by using the same dotted path, or you
 retrieve the entire collection as a JSON document by specifying their common key:
 
 .. terminal::
-    :input: snapctl get server
-    :user: crafter
-    :host: host
+    :user:
+    :host:
+    :dir:
+
+    snapctl get server
 
     {
         "protocol": "tcp",

--- a/docs/how-to/change-bases/change-from-core18-to-core20.rst
+++ b/docs/how-to/change-bases/change-from-core18-to-core20.rst
@@ -229,7 +229,11 @@ Plugins can now be queried with the ``snapcraft help <plugin name> --base <base 
 command:
 
 .. terminal::
-    :input: snapcraft help npm --base core20
+    :user:
+    :host:
+    :dir:
+
+    snapcraft help npm --base core20
 
     Displaying help for the 'npm' plugin for 'core20'.
     [...]
@@ -238,7 +242,11 @@ You can also list plugins for a specific base with ``snapcraft list plugins --ba
 name>``:
 
 .. terminal::
-    :input: snapcraft plugins --base core20
+    :user:
+    :host:
+    :dir:
+
+    snapcraft plugins --base core20
 
     Displaying plugins available for 'core20'
     autotools  catkin  catkin-tools  cmake  colcon  dump  go  make

--- a/docs/how-to/crafting/add-a-snap-configuration.rst
+++ b/docs/how-to/crafting/add-a-snap-configuration.rst
@@ -206,13 +206,20 @@ Build and install the snap.
 Then, test getting and setting the port with:
 
 .. terminal::
-    :user: crafter
-    :host: home
-    :input: snap set example-server ports.http=8090
+    :user:
+    :host:
+    :dir:
 
-    :input: snap get domoticz-gm ports.http
+    snap set example-server ports.http=8090
+
+.. terminal::
+    :user:
+    :host:
+    :dir:
+
+    snap get domoticz-gm ports.http
+
     8090
-
 
 Example live snap
 -----------------

--- a/docs/how-to/crafting/manage-dependencies.rst
+++ b/docs/how-to/crafting/manage-dependencies.rst
@@ -107,6 +107,7 @@ snap:
 A typical missing build dependency will generate an error similar to the following:
 
 .. terminal::
+    :output-only:
 
     configure: error: can't find the Boehm GC library.  Please install it.
     Failed to run 'override-build': Exit code was 1.
@@ -130,6 +131,7 @@ list that can be copied and pasted into the snap's project file. The output will
 similar to the following:
 
 .. terminal::
+    :output-only:
 
     The 'example' part is missing libraries that are not included in the snap or base. They can be satisfied by adding the following entries to the existing stage-packages for this part:
     - libxext6
@@ -145,6 +147,7 @@ running its executable will result in an error. The reasons for these errors are
 but the most common is a missing library, as shown in the following example output:
 
 .. terminal::
+    :output-only:
 
     /snap/mysnap/current/bin/mybin: error while loading shared libraries: libpaho-mqtt3a.so.1: cannot open shared object file: No such file or directory
 

--- a/docs/how-to/debugging/debug-a-snap.rst
+++ b/docs/how-to/debugging/debug-a-snap.rst
@@ -132,6 +132,7 @@ step, run:
 The last line of the output contains a bang (#), indicating you're in a shell:
 
 .. terminal::
+    :output-only:
 
     Using 'snap/snapcraft.yaml': Project assets will be searched for from
     the 'snap' directory.
@@ -171,6 +172,7 @@ usually easy to resolve.
 For example, the following error is related to a missing key:
 
 .. terminal::
+    :output-only:
 
     Issues while validating snapcraft.yaml: 'adopt-info' is a required property or
     'version' is a required property:
@@ -183,6 +185,7 @@ processed until later in the build, which means any error in adopt-info isn't ge
 until the prime step:
 
 .. terminal::
+    :output-only:
 
     Failed to generate snap metadata: 'adopt-info' refers to part 'mypart', but that
     part is lacking the 'parse-info' property.
@@ -207,6 +210,7 @@ with the part that's failing to build, before updating your snap.
 As an example:
 
 .. terminal::
+    :output-only:
 
     Package ncursesw was not found in the pkg-config search path.
     Perhaps you should add the directory containing 'ncursesw.pc'
@@ -245,6 +249,7 @@ system.
 For example:
 
 .. terminal::
+    :output-only:
 
     Unable to successfully call git binary. If git is not in $PATH then please set the
     config variable git-binary-file-path

--- a/docs/how-to/debugging/debug-with-gdb.rst
+++ b/docs/how-to/debugging/debug-with-gdb.rst
@@ -39,9 +39,11 @@ To start a gdbserver session with a local snap, run:
 This enters a gdbserver shell:
 
 .. terminal::
-    :input: snap run --gdbserver test-gdb
-    :user: crafter
-    :host: home
+    :user:
+    :host:
+    :dir:
+
+    snap run --gdbserver test-gdb
 
     Welcome to "snap run --gdbserver".
     You are right before your application is run.
@@ -61,14 +63,15 @@ You can specify a port when starting the gdbserver. For example, to use port 430
 The GDB session can now be accessed from an IDE or GDB itself:
 
 .. terminal::
-    :input: gdb -ex="target remote :43041"
-    :user: crafter
-    :host: home
+    :user:
+    :host:
+    :dir:
+
+    gdb -ex="target remote :43041"
 
     GNU gdb (Ubuntu 12.1-0ubuntu1~22.04) 12.1
     [...]
     (gdb)
-
 
 Remotely debug with gdbserver
 -----------------------------
@@ -90,9 +93,11 @@ used by gdbserver:
 For example, to connect to a gdbserver session at 192.168.122.138 on port 43041:
 
 .. terminal::
-    :input: gdb -ex="target remote 192.168.122.138:43041"
-    :user: crafter
-    :host: home
+    :user:
+    :host:
+    :dir:
+
+    gdb -ex="target remote 192.168.122.138:43041"
 
     Welcome to "snap run --gdbserver".
     You are right before your application is run.
@@ -102,7 +107,6 @@ For example, to connect to a gdbserver session at 192.168.122.138 on port 43041:
     (gdb) continue
 
     or use your favorite gdb frontend and connect to :43041
-
 
 Debug with VS Code and gdbserver
 --------------------------------

--- a/docs/how-to/extensions/expand-extensions.rst
+++ b/docs/how-to/extensions/expand-extensions.rst
@@ -10,9 +10,11 @@ project's root directory to see how the project file will look with the extensio
 applied.
 
 .. terminal::
-    :user: crafter
-    :host: home
-    :input: snapcraft expand-extensions
+    :user:
+    :host:
+    :dir:
+
+    snapcraft expand-extensions
 
     name: foliate
     [...]

--- a/docs/how-to/extensions/list-extensions.rst
+++ b/docs/how-to/extensions/list-extensions.rst
@@ -13,7 +13,10 @@ list all extensions supported by the installed version of Snapcraft, run:
 The output includes all extensions, both stable and experimental, without
 differentiating them.
 
+.. vale off
+
 .. terminal::
+    :output-only:
 
     Extension name          Supported bases
     ----------------------  ------------------------------
@@ -29,5 +32,7 @@ differentiating them.
     gpu                     core22, core24, core26
     kde-neon                core18, core20, core22, core24
     [...]
+
+.. vale on
 
 For the full reference for this command, see :ref:`ref_commands_extensions`.

--- a/docs/how-to/integrations/craft-a-cross-compiled-app.rst
+++ b/docs/how-to/integrations/craft-a-cross-compiled-app.rst
@@ -114,7 +114,11 @@ Because linters are enabled by default for core24 and higher snaps, this will
 produce warnings like the following:
 
 .. terminal::
-    :input: snapcraft
+    :user:
+    :host:
+    :dir:
+
+    snapcraft pack
 
     not a dynamic executable
     arm-binfmt-P: Could not open '/lib/ld-linux-armhf.so.3': No such file or directory

--- a/docs/how-to/publishing/authenticate.rst
+++ b/docs/how-to/publishing/authenticate.rst
@@ -95,7 +95,11 @@ working with:
 This should output your account information as follows:
 
 .. terminal::
-    :input: snapcraft whoami
+    :user:
+    :host:
+    :dir:
+
+    snapcraft whoami
 
     email: <account-email>
     username: <account-name>
@@ -104,7 +108,6 @@ This should output your account information as follows:
     package_push, package_register, package_release, package_update
     channels: no restrictions
     expires: 2026-03-17T14:29:45.000Z
-
 
 Authenticate with a keyring
 ---------------------------

--- a/docs/how-to/publishing/check-a-snaps-status.rst
+++ b/docs/how-to/publishing/check-a-snaps-status.rst
@@ -38,6 +38,7 @@ channel status, run:
 If your account authored the snap, the output lists the current revisions by channel.
 
 .. terminal::
+    :output-only:
 
     Track    Arch     Channel    Version    Revision
     latest   amd64    stable     61d336a    127
@@ -54,6 +55,7 @@ to its target deployment percentage. For example, a progressive release of the s
 channel with a deployment target of 30% would produce output like the following.
 
 .. terminal::
+    :output-only:
 
     Track     Arch    Channel    Version    Revision    Progress
     latest    amd64   stable     4.1246     341         73 → 70%
@@ -81,6 +83,7 @@ The output is ordered by revision number, and contains the revisions for all
 architectures.
 
 .. terminal::
+    :output-only:
 
     Rev.    Uploaded              Arches    Version              Channels
     175     2025-03-13T09:26:16Z  riscv64   v0.29.0-6-gc772624   latest/edge*
@@ -124,7 +127,11 @@ This returns the name, registration date, and visibility of all snaps associated
 the current account.
 
 .. terminal::
-    :input: snapcraft names
+    :user:
+    :host:
+    :dir:
+
+    snapcraft names
 
     Name             Since                 Visibility    Notes
     cameractrls      2022-11-28T18:15:44Z  public        -

--- a/docs/how-to/publishing/get-snap-metrics.rst
+++ b/docs/how-to/publishing/get-snap-metrics.rst
@@ -34,6 +34,7 @@ The returned data, if available, consists of the daily value for the metric acro
 versions:
 
 .. terminal::
+    :output-only:
 
     Version  2025-03-03  2025-03-04  2025-03-05  2025-03-06  2025-03-07  2025-03-08
     V0.27.0  21          20          22          16          0           0
@@ -129,6 +130,7 @@ account, start by logging in and out of Snapcraft to refresh your session permis
 Otherwise, you might get this error:
 
 .. terminal::
+    :output-only:
 
     Errors:
     - Code: macaroon-permission-required

--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -57,6 +57,7 @@ A hook can be added to a snap by placing the hook executable in the project's
 hook executable:
 
 .. terminal::
+   :output-only:
 
    .
    └── snap

--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -12,6 +12,7 @@ This section contains an in-depth description of the plugins available in Snapcr
     /common/craft-parts/reference/plugins/dotnet_v2_plugin
     /common/craft-parts/reference/plugins/ant_plugin
     /common/craft-parts/reference/plugins/autotools_plugin
+    /common/craft-parts/reference/plugins/bazel_plugin
     /common/craft-parts/reference/plugins/cargo_use_plugin
     plugins/crystal_plugin
     plugins/catkin_plugin
@@ -31,6 +32,7 @@ This section contains an in-depth description of the plugins available in Snapcr
     /common/craft-parts/reference/plugins/meson_plugin
     /common/craft-parts/reference/plugins/nil_plugin
     /common/craft-parts/reference/plugins/npm_plugin
+    /common/craft-parts/reference/plugins/npm_use_plugin
     plugins/poetry_plugin
     plugins/python_plugin
     /common/craft-parts/reference/plugins/qmake_plugin

--- a/docs/reference/processes/snap-build-process.rst
+++ b/docs/reference/processes/snap-build-process.rst
@@ -91,6 +91,7 @@ Typically, the content of a snap will resemble a Linux filesystem layout, like
 this:
 
 .. terminal::
+    :output-only:
 
     drwxr-xr-x 10 igor igor  4096 Jun 10  2020 ./
     drwxrwxrwx 14 igor igor 16384 Oct 17 16:40 ../

--- a/docs/release-notes/snapcraft-8-12.rst
+++ b/docs/release-notes/snapcraft-8-12.rst
@@ -51,7 +51,12 @@ The output of ``snapcraft status`` was reworked to allow for easier parsing.
 Prior to the change, the output was formatted as follows:
 
 .. terminal::
-    :input: snapcraft status snapcraft | grep pr- | head
+    :user:
+    :host:
+    :dir:
+
+    snapcraft status snapcraft | grep pr- | head
+
                       edge/pr-5718  8.11.1.post15             15744       -           2025-09-19T00:00:00Z
                       edge/pr-5715  8.11.1.post10             15719       -           2025-09-18T00:00:00Z
                       edge/pr-5714  8.11.1.post10             15712       -           2025-09-18T00:00:00Z
@@ -66,7 +71,11 @@ Prior to the change, the output was formatted as follows:
 The same status query now produces the following output:
 
 .. terminal::
-    :input: snapcraft status snapcraft | grep pr- | head
+    :user:
+    :host:
+    :dir:
+
+    snapcraft status snapcraft | grep pr- | head
 
     latest   amd64    edge/pr-5718  8.11.1.post15             15744       -           2025-09-19T00:00:00Z
     latest   amd64    edge/pr-5715  8.11.1.post10             15719       -           2025-09-18T00:00:00Z

--- a/docs/tutorials/craft-a-snap.rst
+++ b/docs/tutorials/craft-a-snap.rst
@@ -370,9 +370,11 @@ these flags.
 At long last, let's try running our snap.
 
 .. terminal::
-    :input: ukuzama-pyfiglet hello, world!
-    :user: crafter
-    :host: home
+    :user:
+    :host:
+    :dir:
+
+    ukuzama-pyfiglet hello, world!
 
      _          _ _                             _     _ _
     | |__   ___| | | ___    __      _____  _ __| | __| | |
@@ -384,9 +386,11 @@ At long last, let's try running our snap.
 Pyfiglet can draw with different typeface styles, too. It's a fun little command.
 
 .. terminal::
-    :input: ukuzama-pyfiglet -f smscript ciao, mondo!
-    :user: crafter
-    :host: home
+    :user:
+    :host:
+    :dir:
+
+    ukuzama-pyfiglet -f smscript ciao, mondo!
 
      _  o  _,   _              _         _|   _  |
     /   | / |  / \_   /|/|/|  / \_/|/|  / |  / \_|
@@ -448,9 +452,11 @@ As a result, all the fonts are now copied into the snap. Let's give it a try. Re
 snap, reinstall it, and then try it with one of the new fonts:
 
 .. terminal::
-    :input: ukuzama-pyfiglet -f thin bonjour le monde
-    :user: crafter
-    :host: home
+    :user:
+    :host:
+    :dir:
+
+    ukuzama-pyfiglet -f thin bonjour le monde
 
     |                  o                   |                                |
     |---.,---.,---.    .,---..   .,---.    |    ,---.    ,-.-.,---.,---.,---|,---.
@@ -573,9 +579,11 @@ project and install it with:
 And give it a try:
 
 .. terminal::
-    :input: ukuzama-pyfiglet -f smbraille hamba kahle
-    :user: crafter
-    :host: home
+    :user:
+    :host:
+    :dir:
+
+    ukuzama-pyfiglet -f smbraille hamba kahle
 
     ⣇⡀ ⢀⣀ ⣀⣀  ⣇⡀ ⢀⣀   ⡇⡠ ⢀⣀ ⣇⡀ ⡇ ⢀⡀
     ⠇⠸ ⠣⠼ ⠇⠇⠇ ⠧⠜ ⠣⠼   ⠏⠢ ⠣⠼ ⠇⠸ ⠣ ⠣⠭

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "craft-archives>=2.2.0",
     "craft-cli>=3.3.0",
     "craft-grammar>=2.3.0",
-    "craft-parts>=2.28.0",
+    "craft-parts>=2.32.0",
     "craft-platforms>=0.10.0",
     "craft-providers>=3.3.0",
     "craft-store>=3.3.0",
@@ -95,7 +95,6 @@ docs = [
     "sphinx-lint~=1.0",
     "sphinxext-rediraffe==0.3.0",
     "sphinx-substitution-extensions==2025.1.2",
-    "sphinx-terminal==0.1.1",
     "sphinx-copybutton",
     {include-group = "docs-starter-pack"},
 ]
@@ -118,7 +117,7 @@ docs-starter-pack = [
     "sphinx-sitemap>=2.6.0",
     # "sphinx-tabs>=3.4.5",
     # Ignore due to deps in Craft Parts
-    # "sphinx-terminal>=1.0.2",
+    "sphinx-terminal>=1.0.2",
     # "sphinx-ubuntu-images>=0.1.0",
     # "sphinx-youtube-links>=0.1.0",
     "sphinxcontrib-jquery>=4.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,6 @@ docs-starter-pack = [
     "sphinx-roles>=0.1.0",
     "sphinx-sitemap>=2.6.0",
     # "sphinx-tabs>=3.4.5",
-    # Ignore due to deps in Craft Parts
     "sphinx-terminal>=1.0.2",
     # "sphinx-ubuntu-images>=0.1.0",
     # "sphinx-youtube-links>=0.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -578,7 +578,7 @@ wheels = [
 
 [[package]]
 name = "craft-parts"
-version = "2.28.0"
+version = "2.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lxml" },
@@ -589,10 +589,11 @@ dependencies = [
     { name = "requests-unixsocket2" },
     { name = "semver" },
     { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'group-9-snapcraft-dev-jammy' and extra == 'group-9-snapcraft-dev-noble') or (extra == 'group-9-snapcraft-dev-jammy' and extra == 'group-9-snapcraft-dev-plucky') or (extra == 'group-9-snapcraft-dev-jammy' and extra == 'group-9-snapcraft-dev-questing') or (extra == 'group-9-snapcraft-dev-jammy' and extra == 'group-9-snapcraft-dev-resolute') or (extra == 'group-9-snapcraft-dev-noble' and extra == 'group-9-snapcraft-dev-plucky') or (extra == 'group-9-snapcraft-dev-noble' and extra == 'group-9-snapcraft-dev-questing') or (extra == 'group-9-snapcraft-dev-noble' and extra == 'group-9-snapcraft-dev-resolute') or (extra == 'group-9-snapcraft-dev-plucky' and extra == 'group-9-snapcraft-dev-questing') or (extra == 'group-9-snapcraft-dev-plucky' and extra == 'group-9-snapcraft-dev-resolute') or (extra == 'group-9-snapcraft-dev-questing' and extra == 'group-9-snapcraft-dev-resolute')" },
+    { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/80/5d2ab6748840460d0d96ae95cf56be6d6c15c57266e4f2ced34ac0f8c44a/craft_parts-2.28.0.tar.gz", hash = "sha256:8de965c14272776c23e1a8836178448bf3dc9baa713a4bd2d68fe686885b093a", size = 887516, upload-time = "2026-01-09T15:03:42.634Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/ce/fcf50bfc440a085b407436bad12a59006fea4d298ad4ec3f3e70cf62910c/craft_parts-2.32.0.tar.gz", hash = "sha256:7cd368db11c57cbb0875b5b8e21128d5cc3b0b6779c1cdc400872fae23fdc1e5", size = 957232, upload-time = "2026-04-10T18:46:02.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/94/a0d43886e362cde5e19c87d60742d766feab0e41e980baa6e31be179b89b/craft_parts-2.28.0-py3-none-any.whl", hash = "sha256:92c839430986afbfb841cd1d58d705ca67a5ee8fee8daa750bef1819ff610a53", size = 529746, upload-time = "2026-01-09T15:03:41.025Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/33/46d220bec4a6237d1b4624c105dc7bbda9300229e54f20a3663b162a4b86/craft_parts-2.32.0-py3-none-any.whl", hash = "sha256:8db60ec3a1b23b5652d095b70cf34f6a52a9668e9fead1c8853f3e1163e98370", size = 547342, upload-time = "2026-04-10T18:45:59.899Z" },
 ]
 
 [[package]]
@@ -2937,6 +2938,7 @@ docs-starter-pack = [
     { name = "sphinx-related-links" },
     { name = "sphinx-roles" },
     { name = "sphinx-sitemap" },
+    { name = "sphinx-terminal" },
     { name = "sphinxcontrib-jquery" },
     { name = "sphinxext-opengraph" },
     { name = "vale" },
@@ -2976,7 +2978,7 @@ requires-dist = [
     { name = "craft-archives", specifier = ">=2.2.0" },
     { name = "craft-cli", specifier = ">=3.3.0" },
     { name = "craft-grammar", specifier = ">=2.3.0" },
-    { name = "craft-parts", specifier = ">=2.28.0" },
+    { name = "craft-parts", specifier = ">=2.32.0" },
     { name = "craft-platforms", specifier = ">=0.10.0" },
     { name = "craft-providers", specifier = ">=3.3.0" },
     { name = "craft-store", specifier = ">=3.3.0" },
@@ -3053,7 +3055,7 @@ docs = [
     { name = "sphinx-roles", specifier = ">=0.1.0" },
     { name = "sphinx-sitemap", specifier = ">=2.6.0" },
     { name = "sphinx-substitution-extensions", specifier = "==2025.1.2" },
-    { name = "sphinx-terminal", specifier = "==0.1.1" },
+    { name = "sphinx-terminal", specifier = ">=1.0.2" },
     { name = "sphinxcontrib-jquery", specifier = ">=4.1" },
     { name = "sphinxext-opengraph", specifier = ">=0.13.0" },
     { name = "sphinxext-rediraffe", specifier = "==0.3.0" },
@@ -3070,6 +3072,7 @@ docs-starter-pack = [
     { name = "sphinx-related-links", specifier = ">=0.1.1" },
     { name = "sphinx-roles", specifier = ">=0.1.0" },
     { name = "sphinx-sitemap", specifier = ">=2.6.0" },
+    { name = "sphinx-terminal", specifier = ">=1.0.2" },
     { name = "sphinxcontrib-jquery", specifier = ">=4.1" },
     { name = "sphinxext-opengraph", specifier = ">=0.13.0" },
     { name = "vale", specifier = ">=3.13.0.0" },
@@ -3325,15 +3328,16 @@ wheels = [
 
 [[package]]
 name = "sphinx-terminal"
-version = "0.1.1"
+version = "1.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils" },
     { name = "sphinx" },
+    { name = "sphinx-copybutton" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/14/3dedb40eabe81082ac4ae940530b8d05bbd191adde18bbe494d23e856461/sphinx_terminal-0.1.1.tar.gz", hash = "sha256:25f1bf84f73908cc73274c363077b54742abb87bae0633acbe267636f9d9944d", size = 93978, upload-time = "2025-10-15T00:08:42.061Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/f7/c48cfa302ba9e82687972334b1995e687cab79999a1805cb3d96d67b80dd/sphinx_terminal-1.0.3.tar.gz", hash = "sha256:7a5ae9d20f5e9fd96d7df753e62b5415e33816a4833b73fcd8d60afee4695cbb", size = 95465, upload-time = "2025-12-02T01:10:18.08Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/aa/19739053afdfbf335c4f5277623dda1adf5122a0f47c83033c032fcf1bb4/sphinx_terminal-0.1.1-py3-none-any.whl", hash = "sha256:6cfd0d7bdc8cedae6a5b8cd65c984a2ab5f6b0c80f3268714948e11701a6fd17", size = 19523, upload-time = "2025-10-15T00:08:40.292Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/09/6afb984b5b58f6d522dea00f59b19ffa2405fb72b298803f51ac3df0f31d/sphinx_terminal-1.0.3-py3-none-any.whl", hash = "sha256:127ca5f21d4a4880bb5f8d18e7114f89d66f96df425478fb376376697e8315ac", size = 20096, upload-time = "2025-12-02T01:10:16.851Z" },
 ]
 
 [[package]]
@@ -3994,4 +3998,94 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/02/cc/b321c51d6936ede296a1b8860cf173bee2928357fe1fff7f97234899173f/zope_interface-8.2-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:aae807efc7bd26302eb2fea05cd6de7d59269ed6ae23a6de1ee47add6de99b8c", size = 264219, upload-time = "2026-01-09T08:05:41.624Z" },
     { url = "https://files.pythonhosted.org/packages/ab/fb/5f5e7b40a2f4efd873fe173624795ca47eaa22e29051270c981361b45209/zope_interface-8.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:05a0e42d6d830f547e114de2e7cd15750dc6c0c78f8138e6c5035e51ddfff37c", size = 264390, upload-time = "2026-01-09T08:05:42.936Z" },
     { url = "https://files.pythonhosted.org/packages/f9/82/3f2bc594370bc3abd58e5f9085d263bf682a222f059ed46275cde0570810/zope_interface-8.2-cp314-cp314-win_amd64.whl", hash = "sha256:561ce42390bee90bae51cf1c012902a8033b2aaefbd0deed81e877562a116d48", size = 212585, upload-time = "2026-01-09T08:05:44.419Z" },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/7a/28efd1d371f1acd037ac64ed1c5e2b41514a6cc937dd6ab6a13ab9f0702f/zstandard-0.25.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e59fdc271772f6686e01e1b3b74537259800f57e24280be3f29c8a0deb1904dd", size = 795256, upload-time = "2025-09-14T22:15:56.415Z" },
+    { url = "https://files.pythonhosted.org/packages/96/34/ef34ef77f1ee38fc8e4f9775217a613b452916e633c4f1d98f31db52c4a5/zstandard-0.25.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4d441506e9b372386a5271c64125f72d5df6d2a8e8a2a45a0ae09b03cb781ef7", size = 640565, upload-time = "2025-09-14T22:15:58.177Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1b/4fdb2c12eb58f31f28c4d28e8dc36611dd7205df8452e63f52fb6261d13e/zstandard-0.25.0-cp310-cp310-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:ab85470ab54c2cb96e176f40342d9ed41e58ca5733be6a893b730e7af9c40550", size = 5345306, upload-time = "2025-09-14T22:16:00.165Z" },
+    { url = "https://files.pythonhosted.org/packages/73/28/a44bdece01bca027b079f0e00be3b6bd89a4df180071da59a3dd7381665b/zstandard-0.25.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e05ab82ea7753354bb054b92e2f288afb750e6b439ff6ca78af52939ebbc476d", size = 5055561, upload-time = "2025-09-14T22:16:02.22Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/74/68341185a4f32b274e0fc3410d5ad0750497e1acc20bd0f5b5f64ce17785/zstandard-0.25.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:78228d8a6a1c177a96b94f7e2e8d012c55f9c760761980da16ae7546a15a8e9b", size = 5402214, upload-time = "2025-09-14T22:16:04.109Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/67/f92e64e748fd6aaffe01e2b75a083c0c4fd27abe1c8747fee4555fcee7dd/zstandard-0.25.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b6bd67528ee8b5c5f10255735abc21aa106931f0dbaf297c7be0c886353c3d0", size = 5449703, upload-time = "2025-09-14T22:16:06.312Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e5/6d36f92a197c3c17729a2125e29c169f460538a7d939a27eaaa6dcfcba8e/zstandard-0.25.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4b6d83057e713ff235a12e73916b6d356e3084fd3d14ced499d84240f3eecee0", size = 5556583, upload-time = "2025-09-14T22:16:08.457Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/83/41939e60d8d7ebfe2b747be022d0806953799140a702b90ffe214d557638/zstandard-0.25.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9174f4ed06f790a6869b41cba05b43eeb9a35f8993c4422ab853b705e8112bbd", size = 5045332, upload-time = "2025-09-14T22:16:10.444Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/87/d3ee185e3d1aa0133399893697ae91f221fda79deb61adbe998a7235c43f/zstandard-0.25.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:25f8f3cd45087d089aef5ba3848cd9efe3ad41163d3400862fb42f81a3a46701", size = 5572283, upload-time = "2025-09-14T22:16:12.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1d/58635ae6104df96671076ac7d4ae7816838ce7debd94aecf83e30b7121b0/zstandard-0.25.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3756b3e9da9b83da1796f8809dd57cb024f838b9eeafde28f3cb472012797ac1", size = 4959754, upload-time = "2025-09-14T22:16:14.225Z" },
+    { url = "https://files.pythonhosted.org/packages/75/d6/57e9cb0a9983e9a229dd8fd2e6e96593ef2aa82a3907188436f22b111ccd/zstandard-0.25.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:81dad8d145d8fd981b2962b686b2241d3a1ea07733e76a2f15435dfb7fb60150", size = 5266477, upload-time = "2025-09-14T22:16:16.343Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a9/ee891e5edf33a6ebce0a028726f0bbd8567effe20fe3d5808c42323e8542/zstandard-0.25.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:a5a419712cf88862a45a23def0ae063686db3d324cec7edbe40509d1a79a0aab", size = 5440914, upload-time = "2025-09-14T22:16:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/58/08/a8522c28c08031a9521f27abc6f78dbdee7312a7463dd2cfc658b813323b/zstandard-0.25.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:e7360eae90809efd19b886e59a09dad07da4ca9ba096752e61a2e03c8aca188e", size = 5819847, upload-time = "2025-09-14T22:16:20.559Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/11/4c91411805c3f7b6f31c60e78ce347ca48f6f16d552fc659af6ec3b73202/zstandard-0.25.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:75ffc32a569fb049499e63ce68c743155477610532da1eb38e7f24bf7cd29e74", size = 5363131, upload-time = "2025-09-14T22:16:22.206Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d6/8c4bd38a3b24c4c7676a7a3d8de85d6ee7a983602a734b9f9cdefb04a5d6/zstandard-0.25.0-cp310-cp310-win32.whl", hash = "sha256:106281ae350e494f4ac8a80470e66d1fe27e497052c8d9c3b95dc4cf1ade81aa", size = 436469, upload-time = "2025-09-14T22:16:25.002Z" },
+    { url = "https://files.pythonhosted.org/packages/93/90/96d50ad417a8ace5f841b3228e93d1bb13e6ad356737f42e2dde30d8bd68/zstandard-0.25.0-cp310-cp310-win_amd64.whl", hash = "sha256:ea9d54cc3d8064260114a0bbf3479fc4a98b21dffc89b3459edd506b69262f6e", size = 506100, upload-time = "2025-09-14T22:16:23.569Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/83/c3ca27c363d104980f1c9cee1101cc8ba724ac8c28a033ede6aab89585b1/zstandard-0.25.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:933b65d7680ea337180733cf9e87293cc5500cc0eb3fc8769f4d3c88d724ec5c", size = 795254, upload-time = "2025-09-14T22:16:26.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/4d/e66465c5411a7cf4866aeadc7d108081d8ceba9bc7abe6b14aa21c671ec3/zstandard-0.25.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3f79487c687b1fc69f19e487cd949bf3aae653d181dfb5fde3bf6d18894706f", size = 640559, upload-time = "2025-09-14T22:16:27.973Z" },
+    { url = "https://files.pythonhosted.org/packages/12/56/354fe655905f290d3b147b33fe946b0f27e791e4b50a5f004c802cb3eb7b/zstandard-0.25.0-cp311-cp311-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:0bbc9a0c65ce0eea3c34a691e3c4b6889f5f3909ba4822ab385fab9057099431", size = 5348020, upload-time = "2025-09-14T22:16:29.523Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/13/2b7ed68bd85e69a2069bcc72141d378f22cae5a0f3b353a2c8f50ef30c1b/zstandard-0.25.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:01582723b3ccd6939ab7b3a78622c573799d5d8737b534b86d0e06ac18dbde4a", size = 5058126, upload-time = "2025-09-14T22:16:31.811Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/dd/fdaf0674f4b10d92cb120ccff58bbb6626bf8368f00ebfd2a41ba4a0dc99/zstandard-0.25.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5f1ad7bf88535edcf30038f6919abe087f606f62c00a87d7e33e7fc57cb69fcc", size = 5405390, upload-time = "2025-09-14T22:16:33.486Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/67/354d1555575bc2490435f90d67ca4dd65238ff2f119f30f72d5cde09c2ad/zstandard-0.25.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:06acb75eebeedb77b69048031282737717a63e71e4ae3f77cc0c3b9508320df6", size = 5452914, upload-time = "2025-09-14T22:16:35.277Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/e9cfd801a3f9190bf3e759c422bbfd2247db9d7f3d54a56ecde70137791a/zstandard-0.25.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9300d02ea7c6506f00e627e287e0492a5eb0371ec1670ae852fefffa6164b072", size = 5559635, upload-time = "2025-09-14T22:16:37.141Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/5ba550f797ca953a52d708c8e4f380959e7e3280af029e38fbf47b55916e/zstandard-0.25.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:bfd06b1c5584b657a2892a6014c2f4c20e0db0208c159148fa78c65f7e0b0277", size = 5048277, upload-time = "2025-09-14T22:16:38.807Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c0/ca3e533b4fa03112facbe7fbe7779cb1ebec215688e5df576fe5429172e0/zstandard-0.25.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f373da2c1757bb7f1acaf09369cdc1d51d84131e50d5fa9863982fd626466313", size = 5574377, upload-time = "2025-09-14T22:16:40.523Z" },
+    { url = "https://files.pythonhosted.org/packages/12/9b/3fb626390113f272abd0799fd677ea33d5fc3ec185e62e6be534493c4b60/zstandard-0.25.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6c0e5a65158a7946e7a7affa6418878ef97ab66636f13353b8502d7ea03c8097", size = 4961493, upload-time = "2025-09-14T22:16:43.3Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/d3/23094a6b6a4b1343b27ae68249daa17ae0651fcfec9ed4de09d14b940285/zstandard-0.25.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:c8e167d5adf59476fa3e37bee730890e389410c354771a62e3c076c86f9f7778", size = 5269018, upload-time = "2025-09-14T22:16:45.292Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/a7/bb5a0c1c0f3f4b5e9d5b55198e39de91e04ba7c205cc46fcb0f95f0383c1/zstandard-0.25.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:98750a309eb2f020da61e727de7d7ba3c57c97cf6213f6f6277bb7fb42a8e065", size = 5443672, upload-time = "2025-09-14T22:16:47.076Z" },
+    { url = "https://files.pythonhosted.org/packages/27/22/503347aa08d073993f25109c36c8d9f029c7d5949198050962cb568dfa5e/zstandard-0.25.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:22a086cff1b6ceca18a8dd6096ec631e430e93a8e70a9ca5efa7561a00f826fa", size = 5822753, upload-time = "2025-09-14T22:16:49.316Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/be/94267dc6ee64f0f8ba2b2ae7c7a2df934a816baaa7291db9e1aa77394c3c/zstandard-0.25.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:72d35d7aa0bba323965da807a462b0966c91608ef3a48ba761678cb20ce5d8b7", size = 5366047, upload-time = "2025-09-14T22:16:51.328Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a3/732893eab0a3a7aecff8b99052fecf9f605cf0fb5fb6d0290e36beee47a4/zstandard-0.25.0-cp311-cp311-win32.whl", hash = "sha256:f5aeea11ded7320a84dcdd62a3d95b5186834224a9e55b92ccae35d21a8b63d4", size = 436484, upload-time = "2025-09-14T22:16:55.005Z" },
+    { url = "https://files.pythonhosted.org/packages/43/a3/c6155f5c1cce691cb80dfd38627046e50af3ee9ddc5d0b45b9b063bfb8c9/zstandard-0.25.0-cp311-cp311-win_amd64.whl", hash = "sha256:daab68faadb847063d0c56f361a289c4f268706b598afbf9ad113cbe5c38b6b2", size = 506183, upload-time = "2025-09-14T22:16:52.753Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/3e/8945ab86a0820cc0e0cdbf38086a92868a9172020fdab8a03ac19662b0e5/zstandard-0.25.0-cp311-cp311-win_arm64.whl", hash = "sha256:22a06c5df3751bb7dc67406f5374734ccee8ed37fc5981bf1ad7041831fa1137", size = 462533, upload-time = "2025-09-14T22:16:53.878Z" },
+    { url = "https://files.pythonhosted.org/packages/82/fc/f26eb6ef91ae723a03e16eddb198abcfce2bc5a42e224d44cc8b6765e57e/zstandard-0.25.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7b3c3a3ab9daa3eed242d6ecceead93aebbb8f5f84318d82cee643e019c4b73b", size = 795738, upload-time = "2025-09-14T22:16:56.237Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1c/d920d64b22f8dd028a8b90e2d756e431a5d86194caa78e3819c7bf53b4b3/zstandard-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:913cbd31a400febff93b564a23e17c3ed2d56c064006f54efec210d586171c00", size = 640436, upload-time = "2025-09-14T22:16:57.774Z" },
+    { url = "https://files.pythonhosted.org/packages/53/6c/288c3f0bd9fcfe9ca41e2c2fbfd17b2097f6af57b62a81161941f09afa76/zstandard-0.25.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:011d388c76b11a0c165374ce660ce2c8efa8e5d87f34996aa80f9c0816698b64", size = 5343019, upload-time = "2025-09-14T22:16:59.302Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/15/efef5a2f204a64bdb5571e6161d49f7ef0fffdbca953a615efbec045f60f/zstandard-0.25.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dffecc361d079bb48d7caef5d673c88c8988d3d33fb74ab95b7ee6da42652ea", size = 5063012, upload-time = "2025-09-14T22:17:01.156Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/37/a6ce629ffdb43959e92e87ebdaeebb5ac81c944b6a75c9c47e300f85abdf/zstandard-0.25.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7149623bba7fdf7e7f24312953bcf73cae103db8cae49f8154dd1eadc8a29ecb", size = 5394148, upload-time = "2025-09-14T22:17:03.091Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/79/2bf870b3abeb5c070fe2d670a5a8d1057a8270f125ef7676d29ea900f496/zstandard-0.25.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6a573a35693e03cf1d67799fd01b50ff578515a8aeadd4595d2a7fa9f3ec002a", size = 5451652, upload-time = "2025-09-14T22:17:04.979Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/7be26e610767316c028a2cbedb9a3beabdbe33e2182c373f71a1c0b88f36/zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a56ba0db2d244117ed744dfa8f6f5b366e14148e00de44723413b2f3938a902", size = 5546993, upload-time = "2025-09-14T22:17:06.781Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c7/3483ad9ff0662623f3648479b0380d2de5510abf00990468c286c6b04017/zstandard-0.25.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:10ef2a79ab8e2974e2075fb984e5b9806c64134810fac21576f0668e7ea19f8f", size = 5046806, upload-time = "2025-09-14T22:17:08.415Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b3/206883dd25b8d1591a1caa44b54c2aad84badccf2f1de9e2d60a446f9a25/zstandard-0.25.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aaf21ba8fb76d102b696781bddaa0954b782536446083ae3fdaa6f16b25a1c4b", size = 5576659, upload-time = "2025-09-14T22:17:10.164Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/31/76c0779101453e6c117b0ff22565865c54f48f8bd807df2b00c2c404b8e0/zstandard-0.25.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1869da9571d5e94a85a5e8d57e4e8807b175c9e4a6294e3b66fa4efb074d90f6", size = 4953933, upload-time = "2025-09-14T22:17:11.857Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e1/97680c664a1bf9a247a280a053d98e251424af51f1b196c6d52f117c9720/zstandard-0.25.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:809c5bcb2c67cd0ed81e9229d227d4ca28f82d0f778fc5fea624a9def3963f91", size = 5268008, upload-time = "2025-09-14T22:17:13.627Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/73/316e4010de585ac798e154e88fd81bb16afc5c5cb1a72eeb16dd37e8024a/zstandard-0.25.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f27662e4f7dbf9f9c12391cb37b4c4c3cb90ffbd3b1fb9284dadbbb8935fa708", size = 5433517, upload-time = "2025-09-14T22:17:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/60/dd0f8cfa8129c5a0ce3ea6b7f70be5b33d2618013a161e1ff26c2b39787c/zstandard-0.25.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99c0c846e6e61718715a3c9437ccc625de26593fea60189567f0118dc9db7512", size = 5814292, upload-time = "2025-09-14T22:17:17.827Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5f/75aafd4b9d11b5407b641b8e41a57864097663699f23e9ad4dbb91dc6bfe/zstandard-0.25.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:474d2596a2dbc241a556e965fb76002c1ce655445e4e3bf38e5477d413165ffa", size = 5360237, upload-time = "2025-09-14T22:17:19.954Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8d/0309daffea4fcac7981021dbf21cdb2e3427a9e76bafbcdbdf5392ff99a4/zstandard-0.25.0-cp312-cp312-win32.whl", hash = "sha256:23ebc8f17a03133b4426bcc04aabd68f8236eb78c3760f12783385171b0fd8bd", size = 436922, upload-time = "2025-09-14T22:17:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3b/fa54d9015f945330510cb5d0b0501e8253c127cca7ebe8ba46a965df18c5/zstandard-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffef5a74088f1e09947aecf91011136665152e0b4b359c42be3373897fb39b01", size = 506276, upload-time = "2025-09-14T22:17:21.429Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/6b/8b51697e5319b1f9ac71087b0af9a40d8a6288ff8025c36486e0c12abcc4/zstandard-0.25.0-cp312-cp312-win_arm64.whl", hash = "sha256:181eb40e0b6a29b3cd2849f825e0fa34397f649170673d385f3598ae17cca2e9", size = 462679, upload-time = "2025-09-14T22:17:23.147Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0b/8df9c4ad06af91d39e94fa96cc010a24ac4ef1378d3efab9223cc8593d40/zstandard-0.25.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec996f12524f88e151c339688c3897194821d7f03081ab35d31d1e12ec975e94", size = 795735, upload-time = "2025-09-14T22:17:26.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/06/9ae96a3e5dcfd119377ba33d4c42a7d89da1efabd5cb3e366b156c45ff4d/zstandard-0.25.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1a4ae2dec3993a32247995bdfe367fc3266da832d82f8438c8570f989753de1", size = 640440, upload-time = "2025-09-14T22:17:27.366Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/14/933d27204c2bd404229c69f445862454dcc101cd69ef8c6068f15aaec12c/zstandard-0.25.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:e96594a5537722fdfb79951672a2a63aec5ebfb823e7560586f7484819f2a08f", size = 5343070, upload-time = "2025-09-14T22:17:28.896Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/db/ddb11011826ed7db9d0e485d13df79b58586bfdec56e5c84a928a9a78c1c/zstandard-0.25.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bfc4e20784722098822e3eee42b8e576b379ed72cca4a7cb856ae733e62192ea", size = 5063001, upload-time = "2025-09-14T22:17:31.044Z" },
+    { url = "https://files.pythonhosted.org/packages/db/00/87466ea3f99599d02a5238498b87bf84a6348290c19571051839ca943777/zstandard-0.25.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:457ed498fc58cdc12fc48f7950e02740d4f7ae9493dd4ab2168a47c93c31298e", size = 5394120, upload-time = "2025-09-14T22:17:32.711Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/95/fc5531d9c618a679a20ff6c29e2b3ef1d1f4ad66c5e161ae6ff847d102a9/zstandard-0.25.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fd7a5004eb1980d3cefe26b2685bcb0b17989901a70a1040d1ac86f1d898c551", size = 5451230, upload-time = "2025-09-14T22:17:34.41Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4b/e3678b4e776db00f9f7b2fe58e547e8928ef32727d7a1ff01dea010f3f13/zstandard-0.25.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e735494da3db08694d26480f1493ad2cf86e99bdd53e8e9771b2752a5c0246a", size = 5547173, upload-time = "2025-09-14T22:17:36.084Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d5/ba05ed95c6b8ec30bd468dfeab20589f2cf709b5c940483e31d991f2ca58/zstandard-0.25.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3a39c94ad7866160a4a46d772e43311a743c316942037671beb264e395bdd611", size = 5046736, upload-time = "2025-09-14T22:17:37.891Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d5/870aa06b3a76c73eced65c044b92286a3c4e00554005ff51962deef28e28/zstandard-0.25.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:172de1f06947577d3a3005416977cce6168f2261284c02080e7ad0185faeced3", size = 5576368, upload-time = "2025-09-14T22:17:40.206Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/35/398dc2ffc89d304d59bc12f0fdd931b4ce455bddf7038a0a67733a25f550/zstandard-0.25.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3c83b0188c852a47cd13ef3bf9209fb0a77fa5374958b8c53aaa699398c6bd7b", size = 4954022, upload-time = "2025-09-14T22:17:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/5c/36ba1e5507d56d2213202ec2b05e8541734af5f2ce378c5d1ceaf4d88dc4/zstandard-0.25.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1673b7199bbe763365b81a4f3252b8e80f44c9e323fc42940dc8843bfeaf9851", size = 5267889, upload-time = "2025-09-14T22:17:43.577Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e8/2ec6b6fb7358b2ec0113ae202647ca7c0e9d15b61c005ae5225ad0995df5/zstandard-0.25.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0be7622c37c183406f3dbf0cba104118eb16a4ea7359eeb5752f0794882fc250", size = 5433952, upload-time = "2025-09-14T22:17:45.271Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/01/b5f4d4dbc59ef193e870495c6f1275f5b2928e01ff5a81fecb22a06e22fb/zstandard-0.25.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5f5e4c2a23ca271c218ac025bd7d635597048b366d6f31f420aaeb715239fc98", size = 5814054, upload-time = "2025-09-14T22:17:47.08Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e5/fbd822d5c6f427cf158316d012c5a12f233473c2f9c5fe5ab1ae5d21f3d8/zstandard-0.25.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f187a0bb61b35119d1926aee039524d1f93aaf38a9916b8c4b78ac8514a0aaf", size = 5360113, upload-time = "2025-09-14T22:17:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/69a553d2047f9a2c7347caa225bb3a63b6d7704ad74610cb7823baa08ed7/zstandard-0.25.0-cp313-cp313-win32.whl", hash = "sha256:7030defa83eef3e51ff26f0b7bfb229f0204b66fe18e04359ce3474ac33cbc09", size = 436936, upload-time = "2025-09-14T22:17:52.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/82/b9c06c870f3bd8767c201f1edbdf9e8dc34be5b0fbc5682c4f80fe948475/zstandard-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:1f830a0dac88719af0ae43b8b2d6aef487d437036468ef3c2ea59c51f9d55fd5", size = 506232, upload-time = "2025-09-14T22:17:50.402Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/60c3c01243bb81d381c9916e2a6d9e149ab8627c0c7d7abb2d73384b3c0c/zstandard-0.25.0-cp313-cp313-win_arm64.whl", hash = "sha256:85304a43f4d513f5464ceb938aa02c1e78c2943b29f44a750b48b25ac999a049", size = 462671, upload-time = "2025-09-14T22:17:51.533Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/5c/f8923b595b55fe49e30612987ad8bf053aef555c14f05bb659dd5dbe3e8a/zstandard-0.25.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e29f0cf06974c899b2c188ef7f783607dbef36da4c242eb6c82dcd8b512855e3", size = 795887, upload-time = "2025-09-14T22:17:54.198Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/09/d0a2a14fc3439c5f874042dca72a79c70a532090b7ba0003be73fee37ae2/zstandard-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:05df5136bc5a011f33cd25bc9f506e7426c0c9b3f9954f056831ce68f3b6689f", size = 640658, upload-time = "2025-09-14T22:17:55.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/8b6b71b1ddd517f68ffb55e10834388d4f793c49c6b83effaaa05785b0b4/zstandard-0.25.0-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f604efd28f239cc21b3adb53eb061e2a205dc164be408e553b41ba2ffe0ca15c", size = 5379849, upload-time = "2025-09-14T22:17:57.372Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/86/a48e56320d0a17189ab7a42645387334fba2200e904ee47fc5a26c1fd8ca/zstandard-0.25.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223415140608d0f0da010499eaa8ccdb9af210a543fac54bce15babbcfc78439", size = 5058095, upload-time = "2025-09-14T22:17:59.498Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ad/eb659984ee2c0a779f9d06dbfe45e2dc39d99ff40a319895df2d3d9a48e5/zstandard-0.25.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e54296a283f3ab5a26fc9b8b5d4978ea0532f37b231644f367aa588930aa043", size = 5551751, upload-time = "2025-09-14T22:18:01.618Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b3/b637faea43677eb7bd42ab204dfb7053bd5c4582bfe6b1baefa80ac0c47b/zstandard-0.25.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ca54090275939dc8ec5dea2d2afb400e0f83444b2fc24e07df7fdef677110859", size = 6364818, upload-time = "2025-09-14T22:18:03.769Z" },
+    { url = "https://files.pythonhosted.org/packages/31/dc/cc50210e11e465c975462439a492516a73300ab8caa8f5e0902544fd748b/zstandard-0.25.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e09bb6252b6476d8d56100e8147b803befa9a12cea144bbe629dd508800d1ad0", size = 5560402, upload-time = "2025-09-14T22:18:05.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ae/56523ae9c142f0c08efd5e868a6da613ae76614eca1305259c3bf6a0ed43/zstandard-0.25.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a9ec8c642d1ec73287ae3e726792dd86c96f5681eb8df274a757bf62b750eae7", size = 4955108, upload-time = "2025-09-14T22:18:07.68Z" },
+    { url = "https://files.pythonhosted.org/packages/98/cf/c899f2d6df0840d5e384cf4c4121458c72802e8bda19691f3b16619f51e9/zstandard-0.25.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a4089a10e598eae6393756b036e0f419e8c1d60f44a831520f9af41c14216cf2", size = 5269248, upload-time = "2025-09-14T22:18:09.753Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c0/59e912a531d91e1c192d3085fc0f6fb2852753c301a812d856d857ea03c6/zstandard-0.25.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f67e8f1a324a900e75b5e28ffb152bcac9fbed1cc7b43f99cd90f395c4375344", size = 5430330, upload-time = "2025-09-14T22:18:11.966Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/7e31db1240de2df22a58e2ea9a93fc6e38cc29353e660c0272b6735d6669/zstandard-0.25.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9654dbc012d8b06fc3d19cc825af3f7bf8ae242226df5f83936cb39f5fdc846c", size = 5811123, upload-time = "2025-09-14T22:18:13.907Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/49/fac46df5ad353d50535e118d6983069df68ca5908d4d65b8c466150a4ff1/zstandard-0.25.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4203ce3b31aec23012d3a4cf4a2ed64d12fea5269c49aed5e4c3611b938e4088", size = 5359591, upload-time = "2025-09-14T22:18:16.465Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/38/f249a2050ad1eea0bb364046153942e34abba95dd5520af199aed86fbb49/zstandard-0.25.0-cp314-cp314-win32.whl", hash = "sha256:da469dc041701583e34de852d8634703550348d5822e66a0c827d39b05365b12", size = 444513, upload-time = "2025-09-14T22:18:20.61Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/43/241f9615bcf8ba8903b3f0432da069e857fc4fd1783bd26183db53c4804b/zstandard-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19bcdd826e95671065f8692b5a4aa95c52dc7a02a4c5a0cac46deb879a017a2", size = 516118, upload-time = "2025-09-14T22:18:17.849Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ef/da163ce2450ed4febf6467d77ccb4cd52c4c30ab45624bad26ca0a27260c/zstandard-0.25.0-cp314-cp314-win_arm64.whl", hash = "sha256:d7541afd73985c630bafcd6338d2518ae96060075f9463d7dc14cfb33514383d", size = 476940, upload-time = "2025-09-14T22:18:19.088Z" },
 ]


### PR DESCRIPTION
Bumps craft-parts to 2.32.0.

This required bumping sphinx-terminal and updating the `terminal` directives.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
