### PR TITLE
test(spread): update python tests

### DIFF
--- a/docs/how-to/change-bases/change-from-core24-to-core26.rst
+++ b/docs/how-to/change-bases/change-from-core24-to-core26.rst
@@ -80,9 +80,9 @@ The optimal solution is to define a separate part, and stage the Python runtime 
         stage-packages:
           - libpython3.14-minimal
           - libpython3.14-stdlib
+          - python3-minimal # for the "python3" symlink
           - python3.14-minimal
-          - python3-venv
-          - python3-minimal
+          - python3.14-venv
 
       my-app:
         after: [python-runtime]

--- a/tests/spread/core26/python-hello/classic/snap/snapcraft.yaml
+++ b/tests/spread/core26/python-hello/classic/snap/snapcraft.yaml
@@ -25,6 +25,6 @@ parts:
     stage-packages:
       - libpython3.14-minimal
       - libpython3.14-stdlib
+      - python3-minimal # for the "python3" symlink
       - python3.14-minimal
-      - python3-venv
-      - python3-minimal # (for the "python3" symlink)
+      - python3.14-venv

--- a/tests/spread/core26/python-hello/poetry/snap/snapcraft.yaml
+++ b/tests/spread/core26/python-hello/poetry/snap/snapcraft.yaml
@@ -17,6 +17,6 @@ parts:
     stage-packages:
       - libpython3.14-minimal
       - libpython3.14-stdlib
+      - python3-minimal # for the "python3" symlink
       - python3.14-minimal
-      - python3-venv
-      - python3-minimal # (for the "python3" symlink)
+      - python3.14-venv

--- a/tests/spread/core26/python-hello/strict/snap/snapcraft.yaml
+++ b/tests/spread/core26/python-hello/strict/snap/snapcraft.yaml
@@ -19,6 +19,6 @@ parts:
     stage-packages:
       - libpython3.14-minimal
       - libpython3.14-stdlib
+      - python3-minimal # for the "python3" symlink
       - python3.14-minimal
-      - python3-venv
-      - python3-minimal # (for the "python3" symlink)
+      - python3.14-venv

--- a/tests/spread/core26/python-hello/uv/snap/snapcraft.yaml
+++ b/tests/spread/core26/python-hello/uv/snap/snapcraft.yaml
@@ -19,6 +19,6 @@ parts:
     stage-packages:
       - libpython3.14-minimal
       - libpython3.14-stdlib
+      - python3-minimal # for the "python3" symlink
       - python3.14-minimal
-      - python3-venv
-      - python3-minimal # (for the "python3" symlink)
+      - python3.14-venv

--- a/tests/spread/core26/python-symlinks/bare-provisioned/snapcraft.yaml
+++ b/tests/spread/core26/python-symlinks/bare-provisioned/snapcraft.yaml
@@ -22,6 +22,8 @@ parts:
     source: src
     python-packages: [black]
     stage-packages:
-      - python3-minimal
-      - python3-minimal
-      - python3-venv
+      - libpython3.14-minimal
+      - libpython3.14-stdlib
+      - python3-minimal # for the "python3" symlink
+      - python3.14-minimal
+      - python3.14-venv

--- a/tests/spread/core26/python-symlinks/classic-provisioned/snapcraft.yaml
+++ b/tests/spread/core26/python-symlinks/classic-provisioned/snapcraft.yaml
@@ -22,6 +22,8 @@ parts:
     source: src
     python-packages: [black]
     stage-packages:
-      - python3-minimal
-      - python3-minimal
-      - python3-venv
+      - libpython3.14-minimal
+      - libpython3.14-stdlib
+      - python3-minimal # for the "python3" symlink
+      - python3.14-minimal
+      - python3.14-venv

--- a/tests/spread/core26/python-symlinks/devmode-provisioned/snapcraft.yaml
+++ b/tests/spread/core26/python-symlinks/devmode-provisioned/snapcraft.yaml
@@ -21,6 +21,8 @@ parts:
     source: src
     python-packages: [black]
     stage-packages:
-      - python3-minimal
-      - python3-minimal
-      - python3-venv
+      - libpython3.14-minimal
+      - libpython3.14-stdlib
+      - python3-minimal # for the "python3" symlink
+      - python3.14-minimal
+      - python3.14-venv

--- a/tests/spread/core26/python-symlinks/provisioned-from-another-part/snapcraft.yaml
+++ b/tests/spread/core26/python-symlinks/provisioned-from-another-part/snapcraft.yaml
@@ -28,6 +28,8 @@ parts:
   other-part:
     plugin: nil
     stage-packages:
-      - python3-minimal
-      - python3-minimal
-      - python3-venv
+      - libpython3.14-minimal
+      - libpython3.14-stdlib
+      - python3-minimal # for the "python3" symlink
+      - python3.14-minimal
+      - python3.14-venv

--- a/tests/spread/core26/python-symlinks/strict-provisioned/snapcraft.yaml
+++ b/tests/spread/core26/python-symlinks/strict-provisioned/snapcraft.yaml
@@ -21,6 +21,8 @@ parts:
     source: src
     python-packages: [black]
     stage-packages:
-      - python3-minimal
-      - python3-minimal
-      - python3-venv
+      - libpython3.14-minimal
+      - libpython3.14-stdlib
+      - python3-minimal # for the "python3" symlink
+      - python3.14-minimal
+      - python3.14-venv


### PR DESCRIPTION
The core26 spread tests and documentation didn't use the same ordered set of Python packages. This makes them consistent.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
