### PR TITLE
docs: format doc version as major.minor

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,9 +28,11 @@ project = "Snapcraft"
 author = "Canonical Group Ltd"
 # The full version, including alpha/beta/rc tags
 release = snapcraft.__version__
-# The commit hash in the dev release version confuses the spellchecker
 if ".post" in release:
     release = "dev"
+else:
+    major, minor, *_ = release.split(".")
+    release = f"{major}.{minor}"
 
 copyright = "2015-%s, %s" % (datetime.date.today().year, author)
 


### PR DESCRIPTION
What it says on the tin.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] I've updated the relevant release notes.
