### PR TITLE
feat: allow building stable base snaps

### DIFF
--- a/docs/release-notes/index.rst
+++ b/docs/release-notes/index.rst
@@ -16,6 +16,7 @@ Current releases
 Snapcraft 8
 ~~~~~~~~~~~
 
+- :ref:`Snapcraft 8.15 <release-8.15>`
 - :ref:`Snapcraft 8.14 <release-8.14>`
 - :ref:`Snapcraft 8.13 <release-8.13>`
 - :ref:`Snapcraft 8.12 <release-8.12>`
@@ -88,6 +89,7 @@ development keeps pace with the OS's new releases and support lifecycle.
 .. toctree::
     :hidden:
 
+    Snapcraft 8.15 <snapcraft-8-15>
     Snapcraft 8.14 <snapcraft-8-14>
     Snapcraft 8.13 <snapcraft-8-13>
     Snapcraft 8.12 <snapcraft-8-12>

--- a/docs/release-notes/snapcraft-8-15.rst
+++ b/docs/release-notes/snapcraft-8-15.rst
@@ -1,0 +1,47 @@
+.. _release-8.15:
+
+Snapcraft 8.15 release notes
+============================
+
+14 April 2026
+
+Learn about the new features, changes, and fixes introduced in Snapcraft 8.15.
+
+
+Requirements and compatibility
+------------------------------
+See :ref:`reference-system-requirements` for information on the minimum hardware and
+installed software.
+
+What's new
+----------
+
+Snapcraft 8.15 brings the following features, integrations, and improvements.
+
+Support for bootstrapping stable base snaps
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To allow bootstrapping new bases, base snaps can now be built with ``grade: stable``,
+even when using the ``devel`` build base.
+
+
+Minor features
+--------------
+
+Snapcraft 8.15 brings the following minor changes.
+
+Improved support for packages in the Colcon plugin
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The :ref:`reference-colcon-plugin` now allows you to stage packages from ROS
+content sharing snaps that have no upstream release.
+
+Contributors
+------------
+
+We would like to express a big thank you to all the people who contributed to
+this release.
+
+:literalref:`@Guillaumebeuzeboc <https://github.com/Guillaumebeuzeboc>`,
+:literalref:`@medubelko <https://github.com/medubelko>`,
+and :literalref:`@mr-cal <https://github.com/mr-cal>`.

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -2021,8 +2021,15 @@ class Project(models.Project):
 
     @pydantic.model_validator(mode="after")
     def _validate_grade_and_build_base(self) -> Self:
-        """If build_base is devel, then grade must be devel."""
-        if self.build_base == "devel" and self.grade == "stable":
+        """If build_base is devel, then grade must be devel.
+
+        Base snaps are an exception to this rule, so they can be bootstrapped.
+        """
+        if (
+            self.build_base == "devel"
+            and self.grade == "stable"
+            and self.type != "base"
+        ):
             raise ValueError("grade must be 'devel' when build-base is 'devel'")
         return self
 

--- a/tests/spread/core26/base-snap/snapcraft.yaml
+++ b/tests/spread/core26/base-snap/snapcraft.yaml
@@ -1,0 +1,16 @@
+name: core26
+version: '1.0'
+summary: core26 base snap
+description: Build a core26 base snap with a devel build-base
+confinement: strict
+
+type: base
+build-base: devel
+
+# grade can be stable to allow bootstrapping new bases
+grade: stable
+
+parts:
+  core26:
+    plugin: nil
+    stage-packages: [base-files]

--- a/tests/spread/core26/base-snap/task.yaml
+++ b/tests/spread/core26/base-snap/task.yaml
@@ -1,0 +1,8 @@
+summary: Build a stable core26 base snaps
+
+restore: |
+  snapcraft clean
+  rm -f ./*.snap
+
+execute: |
+  snapcraft pack

--- a/tests/unit/models/test_projects.py
+++ b/tests/unit/models/test_projects.py
@@ -654,6 +654,27 @@ class TestProjectValidation:
 
         assert project.grade == "devel"
 
+    def test_project_base_snap_grade_stable(self, project_yaml_data):
+        """Base snaps can have a stable grade to allow bootstrapping new bases."""
+        project = Project.unmarshal(
+            {
+                "name": "core26",
+                "type": "base",
+                "build-base": "devel",
+                "version": "20260423",
+                "summary": "summary",
+                "description": "description",
+                "grade": "stable",
+                "confinement": "strict",
+                "parts": {},
+            }
+        )
+
+        # the real test is that the unmarshal doesn't raise a validation error, but
+        # we can still assert the import attributes:
+        assert project.type == "base"
+        assert project.grade == "stable"
+
     @pytest.mark.parametrize("build_base", ["core22", "devel"])
     def test_project_grade_not_defined(self, build_base, project_yaml_data):
         """Do not validate the grade if it is not defined, regardless of build_base."""


### PR DESCRIPTION
Allows for building base snaps with `build-base: devel` and `grade: stable` to allow bootstrapping the core26 snap.

I'm putting this feature into a new 8.15 release: https://canonical-ubuntu-documentation-library--6177.com.readthedocs.build/snapcraft/6177/release-notes/snapcraft-8-15/

(SNAPCRAFT-5119)

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [x] I've updated the relevant release notes.
