### PR TITLE
revert: chore!: remove default command

### DIFF
--- a/docs/release-notes/snapcraft-9-0.rst
+++ b/docs/release-notes/snapcraft-9-0.rst
@@ -114,13 +114,6 @@ by their equivalent environment variables:
       - Export the credentials to the environment variable ``SNAPCRAFT_STORE_CREDENTIALS``.
 
 
-Removed default command
-~~~~~~~~~~~~~~~~~~~~~~~
-
-Previously, running ``snapcraft`` alone implicitly ran ``snapcraft pack``. This default
-behavior has been removed. You must now run ``snapcraft pack`` to build a snap.
-
-
 Removed legacy remote builder
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/snapcraft/application.py
+++ b/snapcraft/application.py
@@ -306,7 +306,6 @@ class Snapcraft(Application):
             summary=str(self.app.summary),
             extra_global_args=self._global_arguments,
             default_command=commands.PackCommand,
-            allow_default_command=False,
         )
 
     def _get_project_raw(self) -> dict[str, Any] | None:

--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -212,7 +212,6 @@ def get_dispatcher() -> craft_cli.Dispatcher:
         summary="Package, distribute, and update snaps for Linux and IoT",
         extra_global_args=GLOBAL_ARGS,
         default_command=commands.core22.PackCommand,
-        allow_default_command=False,
     )
 
 

--- a/tests/spread/core22/packing/task.yaml
+++ b/tests/spread/core22/packing/task.yaml
@@ -7,6 +7,9 @@ environment:
   CMD/pack_directory: pack prime
   CMD/pack_directory_output: pack prime --output output.snap
   CMD/pack_directory_output_subdir: pack prime --output subdir/output.snap
+  CMD/default: ""
+  CMD/default_output: -o output.snap
+  CMD/default_output_subdir: --output subdir/output.snap
 
 prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh

--- a/tests/spread/core24/packing/task.yaml
+++ b/tests/spread/core24/packing/task.yaml
@@ -7,6 +7,9 @@ environment:
   CMD/pack_directory: pack prime
   CMD/pack_directory_output: pack prime --output output.snap
   CMD/pack_directory_output_subdir: pack prime --output subdir/output.snap
+  CMD/default: ""
+  CMD/default_output: -o output.snap
+  CMD/default_output_subdir: --output subdir/output.snap
 
 prepare: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh

--- a/tests/spread/core26/basic/task.yaml
+++ b/tests/spread/core26/basic/task.yaml
@@ -1,8 +1,13 @@
 summary: Build a snap using the 'core26' base
 
+environment:
+  COMMAND/default: ""
+  COMMAND/pack: "pack"
+
 restore: |
   snapcraft clean
   rm -f ./*.snap
 
 execute: |
-  snapcraft pack
+  # shellcheck disable=SC2086
+  snapcraft $COMMAND

--- a/tests/spread/general/pack/task.yaml
+++ b/tests/spread/general/pack/task.yaml
@@ -5,6 +5,9 @@ environment:
   COMPRESSION/lzo: lzo
   COMPRESSION/xz: xz
   SNAPCRAFT_BUILD_ENVIRONMENT: ""
+  COMMAND: "pack"
+  COMMAND/default: ""
+  COMMAND/pack: "pack"
 
 prepare: |
   mkdir test-snap

--- a/tests/unit/cli/test_default_command.py
+++ b/tests/unit/cli/test_default_command.py
@@ -14,30 +14,167 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import argparse
 import sys
+from unittest.mock import call
 
 import pytest
 
 from snapcraft import cli
 
 
-@pytest.mark.parametrize(
-    "args",
-    [
-        [],
-        ["--destructive-mode"],
-        ["--use-lxd"],
-        ["-o", "name"],
-        ["--output", "name"],
-        ["--http-proxy", "test-http"],
-        ["--https-proxy", "test-https"],
-    ],
-)
-def test_default_command_with_option(mocker, capsys, args):
-    expected = "Missing a command. Try 'snapcraft pack' or 'snapcraft help'."
-    mocker.patch.object(sys, "argv", ["cmd", *args])
+def test_default_command(mocker):
+    mocker.patch.object(sys, "argv", ["cmd"])
+    mock_pack_cmd = mocker.patch("snapcraft.commands.core22.lifecycle.PackCommand.run")
+    cli.run()
+    assert mock_pack_cmd.mock_calls == [
+        call(
+            argparse.Namespace(
+                debug=False,
+                directory=None,
+                output=None,
+                destructive_mode=False,
+                use_lxd=False,
+                enable_manifest=False,
+                manifest_image_information=None,
+                bind_ssh=False,
+                ua_token=None,
+                build_for=None,
+                enable_experimental_ua_services=False,
+                enable_experimental_plugins=False,
+                http_proxy=None,
+                https_proxy=None,
+            )
+        )
+    ]
 
-    exit_code = cli.run()
 
-    assert exit_code == 1
-    assert expected in capsys.readouterr().err
+def test_default_command_destructive_mode(mocker):
+    mocker.patch.object(sys, "argv", ["cmd", "--destructive-mode"])
+    mock_pack_cmd = mocker.patch("snapcraft.commands.core22.lifecycle.PackCommand.run")
+    cli.run()
+    assert mock_pack_cmd.mock_calls == [
+        call(
+            argparse.Namespace(
+                directory=None,
+                output=None,
+                debug=False,
+                destructive_mode=True,
+                use_lxd=False,
+                enable_manifest=False,
+                manifest_image_information=None,
+                bind_ssh=False,
+                ua_token=None,
+                build_for=None,
+                enable_experimental_ua_services=False,
+                enable_experimental_plugins=False,
+                http_proxy=None,
+                https_proxy=None,
+            )
+        )
+    ]
+
+
+def test_default_command_use_lxd(mocker):
+    mocker.patch.object(sys, "argv", ["cmd", "--use-lxd"])
+    mock_pack_cmd = mocker.patch("snapcraft.commands.core22.lifecycle.PackCommand.run")
+    cli.run()
+    assert mock_pack_cmd.mock_calls == [
+        call(
+            argparse.Namespace(
+                directory=None,
+                output=None,
+                debug=False,
+                destructive_mode=False,
+                use_lxd=True,
+                enable_manifest=False,
+                manifest_image_information=None,
+                bind_ssh=False,
+                ua_token=None,
+                build_for=None,
+                enable_experimental_ua_services=False,
+                enable_experimental_plugins=False,
+                http_proxy=None,
+                https_proxy=None,
+            )
+        )
+    ]
+
+
+@pytest.mark.parametrize("option", ["-o", "--output"])
+def test_default_command_output(mocker, option):
+    mocker.patch.object(sys, "argv", ["cmd", option, "name"])
+    mock_pack_cmd = mocker.patch("snapcraft.commands.core22.lifecycle.PackCommand.run")
+    cli.run()
+    assert mock_pack_cmd.mock_calls == [
+        call(
+            argparse.Namespace(
+                directory=None,
+                output="name",
+                debug=False,
+                destructive_mode=False,
+                use_lxd=False,
+                enable_manifest=False,
+                manifest_image_information=None,
+                bind_ssh=False,
+                ua_token=None,
+                build_for=None,
+                enable_experimental_ua_services=False,
+                enable_experimental_plugins=False,
+                http_proxy=None,
+                https_proxy=None,
+            )
+        )
+    ]
+
+
+def test_default_command_http_proxy(mocker):
+    mocker.patch.object(sys, "argv", ["cmd", "--http-proxy", "test-http"])
+    mock_pack_cmd = mocker.patch("snapcraft.commands.core22.lifecycle.PackCommand.run")
+    cli.run()
+    assert mock_pack_cmd.mock_calls == [
+        call(
+            argparse.Namespace(
+                bind_ssh=False,
+                build_for=None,
+                debug=False,
+                destructive_mode=False,
+                directory=None,
+                enable_experimental_ua_services=False,
+                enable_experimental_plugins=False,
+                enable_manifest=False,
+                http_proxy="test-http",
+                https_proxy=None,
+                manifest_image_information=None,
+                output=None,
+                ua_token=None,
+                use_lxd=False,
+            )
+        )
+    ]
+
+
+def test_default_command_https_proxy(mocker):
+    mocker.patch.object(sys, "argv", ["cmd", "--https-proxy", "test-https"])
+    mock_pack_cmd = mocker.patch("snapcraft.commands.core22.lifecycle.PackCommand.run")
+    cli.run()
+    assert mock_pack_cmd.mock_calls == [
+        call(
+            argparse.Namespace(
+                bind_ssh=False,
+                build_for=None,
+                debug=False,
+                destructive_mode=False,
+                directory=None,
+                enable_experimental_ua_services=False,
+                enable_experimental_plugins=False,
+                enable_manifest=False,
+                http_proxy=None,
+                https_proxy="test-https",
+                manifest_image_information=None,
+                output=None,
+                ua_token=None,
+                use_lxd=False,
+            )
+        )
+    ]

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -38,6 +38,7 @@ from craft_platforms import DebianArchitecture
 from craft_providers import bases
 
 from snapcraft import application, cli, const, services
+from snapcraft.commands import PackCommand
 from snapcraft.errors import ClassicFallback
 from snapcraft.models.project import Architecture
 
@@ -331,30 +332,28 @@ def test_application_maven_use_not_registered(snapcraft_yaml):
     assert "maven-use" not in craft_parts.plugins.get_registered_plugins()
 
 
-@pytest.mark.parametrize(
-    ("base", "exit_code"),
-    [
-        # core22 overrides the error's exit codes
-        ("core22", 1),
-        ("core24", os.EX_USAGE),
-    ],
-)
-def test_default_command_error(snapcraft_yaml, base, exit_code, monkeypatch, capsys):
-    """Invoking snapcraft with no subcommand exits with an error."""
-    snapcraft_yaml(base=base)
-    monkeypatch.setattr("sys.argv", ["snapcraft"])
+def test_default_command_integrated(monkeypatch, mocker, new_dir):
+    """Test that for core24 projects we accept "pack" as the default command."""
 
-    try:
-        # core22 exits with a code, core24 returns an exit code
-        actual_exit_code = application.main()
-    except SystemExit as exc:
-        actual_exit_code = exc.code
-
-    assert actual_exit_code == exit_code
-    assert (
-        "Missing a command. Try 'snapcraft pack' or 'snapcraft help'."
-        in capsys.readouterr().err
+    # Pretend this is an Ubuntu 24.04 system, to match the project's build-base
+    mocker.patch.object(
+        util, "get_host_base", return_value=bases.BaseName("ubuntu", "24.04")
     )
+
+    snap_dir = new_dir / "snap"
+    snap_dir.mkdir()
+
+    # The project itself doesn't really matter.
+    project_yaml = snap_dir / "snapcraft.yaml"
+    project_yaml.write_text(PARSE_INFO_PROJECT)
+
+    mocked_pack_run = mocker.patch.object(PackCommand, "run", return_value=0)
+
+    monkeypatch.setattr("sys.argv", ["snapcraft", "--destructive-mode"])
+    app = application.create_app()
+    app.run()
+
+    assert mocked_pack_run.called
 
 
 @pytest.mark.parametrize("base", const.ESM_BASES)


### PR DESCRIPTION
Reverts #6074 due to not giving advanced notice to maintainers of build scripts (like Launchpad).

Now, the default command is deprecated (again) instead of removed.

We'll plan to remove it when core28 is released, but coordinate the work in advance.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [x] I've updated the relevant release notes.
