### PR TITLE
Fix snapcraft try error to show actual base

### DIFF
--- a/snapcraft/commands/lifecycle.py
+++ b/snapcraft/commands/lifecycle.py
@@ -21,6 +21,7 @@ import textwrap
 from typing import Any
 
 import craft_application.commands
+import craft_application.errors
 from craft_cli import emit
 from typing_extensions import override
 
@@ -120,8 +121,12 @@ class TryCommand(PackCommand):
         step_name: str | None = None,
         **kwargs: Any,
     ) -> None:
-        project = self._services.get("project").get_raw()
-        base = project.get("base", "unknown")
+        base = "unknown"
+        try:
+            project = self._services.get("project").get_raw()
+            base = project.get("base", "unknown")
+        except craft_application.errors.ProjectFileError:
+            pass
         raise snapcraft.errors.FeatureNotImplemented(
             f'"snapcraft try" is not implemented for {base}'
         )

--- a/snapcraft/commands/lifecycle.py
+++ b/snapcraft/commands/lifecycle.py
@@ -120,8 +120,10 @@ class TryCommand(PackCommand):
         step_name: str | None = None,
         **kwargs: Any,
     ) -> None:
+        project = self._services.get("project").get_raw()
+        base = project.get("base", "unknown")
         raise snapcraft.errors.FeatureNotImplemented(
-            '"snapcraft try" is not implemented for core24'
+            f'"snapcraft try" is not implemented for {base}'
         )
 
 

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -99,16 +99,23 @@ def test_snap_command_error(mocker):
 
 
 @pytest.mark.usefixtures("emitter")
-def test_core24_try_command(tmp_path, fake_services):
+@pytest.mark.parametrize("base", ["core24", "core26"])
+def test_try_command(tmp_path, fake_services, mocker, base):
     parsed_args = argparse.Namespace(parts=[], output=tmp_path)
     cmd = lifecycle.TryCommand({"app": APP_METADATA, "services": fake_services})
+
+    mocker.patch.object(
+        fake_services.get("project"),
+        "get_raw",
+        return_value={"base": base},
+    )
 
     with pytest.raises(snapcraft.errors.FeatureNotImplemented) as raised:
         cmd.run(parsed_args=parsed_args)
 
     assert str(raised.value) == (
         'Command or feature not implemented: "snapcraft try" is not '
-        "implemented for core24"
+        f"implemented for {base}"
     )
 
 

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -18,6 +18,7 @@ import argparse
 import re
 from unittest.mock import call
 
+import craft_application.errors
 import pytest
 
 import snapcraft.commands.core22.lifecycle as core22_lifecycle
@@ -116,6 +117,29 @@ def test_try_command(tmp_path, fake_services, mocker, base):
     assert str(raised.value) == (
         'Command or feature not implemented: "snapcraft try" is not '
         f"implemented for {base}"
+    )
+
+
+@pytest.mark.usefixtures("emitter")
+def test_try_command_no_project(tmp_path, fake_services, mocker):
+    """Test that TryCommand falls back to 'unknown' when project file is missing."""
+    parsed_args = argparse.Namespace(parts=[], output=tmp_path)
+    cmd = lifecycle.TryCommand({"app": APP_METADATA, "services": fake_services})
+
+    mocker.patch.object(
+        fake_services.get("project"),
+        "get_raw",
+        side_effect=craft_application.errors.ProjectFileError(
+            "snapcraft.yaml", "File not found."
+        ),
+    )
+
+    with pytest.raises(snapcraft.errors.FeatureNotImplemented) as raised:
+        cmd.run(parsed_args=parsed_args)
+
+    assert str(raised.value) == (
+        'Command or feature not implemented: "snapcraft try" is not '
+        "implemented for unknown"
     )
 
 


### PR DESCRIPTION
## Summary

I ran into this while testing a core26 snap — `snapcraft try` reported "not implemented for core24" even though my `snapcraft.yaml` specifies `base: core26`. The hardcoded string in `TryCommand._run` doesn't reflect the project's actual base, which is confusing when you're troubleshooting why the command failed.

This change reads the project's `base` field via the project service at runtime so the error message accurately reports whichever base the user configured (core24, core26, or anything else).

## Changes

- **`snapcraft/commands/lifecycle.py`**: `TryCommand._run` now fetches the project's raw data to extract the `base` value instead of hardcoding `"core24"`.
- **`tests/unit/commands/test_lifecycle.py`**: Parameterized the existing test with `pytest.mark.parametrize` for both `core24` and `core26`, as the issue requested. The project service's `get_raw` is mocked to return the appropriate base for each test case.

Resolves #6186