### PR TITLE
fix: gpu: use `bind-file` for the X11 layout

### DIFF
--- a/docs/reference/extensions/gpu-extension.rst
+++ b/docs/reference/extensions/gpu-extension.rst
@@ -150,7 +150,7 @@ This extension uses :ref:`layouts <reference-layouts>` to provide access to GPU 
 
                 layout:
                   /usr/share/X11/XErrorDB:
-                    symlink: $SNAP/gpu-2604/X11/XErrorDB
+                    bind-file: $SNAP/gpu-2604/X11/XErrorDB
 
     .. tab-item:: core24
         :sync: core24
@@ -397,7 +397,7 @@ This is the output before build, showing the expanded configuration:
                 +
                 +layout:
                 +  /usr/share/X11/XErrorDB:
-                +    symlink: $SNAP/gpu-2604/X11/XErrorDB
+                +    bind-file: $SNAP/gpu-2604/X11/XErrorDB
                 +
                 apps:
                   my-gpu-app:

--- a/snapcraft/extensions/gpu_extension.py
+++ b/snapcraft/extensions/gpu_extension.py
@@ -80,7 +80,7 @@ class GPUExtension(Extension):
     }
 
     _GPU_2604_LAYOUTS: dict[str, Any] = {
-        "/usr/share/X11/XErrorDB": {"symlink": "$SNAP/gpu-2604/X11/XErrorDB"},
+        "/usr/share/X11/XErrorDB": {"bind-file": "$SNAP/gpu-2604/X11/XErrorDB"},
     }
 
     @staticmethod

--- a/tests/unit/extensions/test_gpu_extension.py
+++ b/tests/unit/extensions/test_gpu_extension.py
@@ -163,7 +163,7 @@ def test_get_root_snippet_core26(gpu_extension_core26):
         },
         "layout": {
             "/usr/share/X11/XErrorDB": {
-                "symlink": "$SNAP/gpu-2604/X11/XErrorDB",
+                "bind-file": "$SNAP/gpu-2604/X11/XErrorDB",
             },
         },
     }


### PR DESCRIPTION
This makes it simpler on snapd to support, as the folder may exist in the base and there's no need to overlay in the mount namespace.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
