### PR TITLE
feat: show progressive percentage in release output

### DIFF
--- a/docs/release-notes/snapcraft-9-0.rst
+++ b/docs/release-notes/snapcraft-9-0.rst
@@ -39,6 +39,14 @@ Interactive key selection for ``register-key``
 The :ref:`ref_commands_register-key` command now prompts you to select a key
 when no key name is given.
 
+Progressive percentage shown after ``release``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The :ref:`ref_commands_release` command now reports the progressive percentage
+when releasing a snap progressively. For example::
+
+    Released 'my-snap' revision 42 to channels: 'stable' for 30% of users
+
 
 Backwards-incompatible changes
 ------------------------------

--- a/snapcraft/commands/manage.py
+++ b/snapcraft/commands/manage.py
@@ -104,10 +104,15 @@ class StoreReleaseCommand(AppCommand):
         )
 
         humanized_channels = utils.humanize_list(channels, conjunction="and")
+        progressive = parsed_args.progressive_percentage
+        progressive_suffix = (
+            f" for {progressive}% of users" if progressive is not None else ""
+        )
         emit.message(
             f"Released {parsed_args.name!r} "
             f"revision {parsed_args.revision!r} "
             f"to channels: {humanized_channels}"
+            f"{progressive_suffix}"
         )
 
 

--- a/tests/unit/commands/test_manage.py
+++ b/tests/unit/commands/test_manage.py
@@ -145,7 +145,9 @@ def test_release_progressive(emitter, fake_store_release, fake_app_config):
             progressive_percentage=10,
         )
     ]
-    emitter.assert_message("Released 'test-snap' revision 10 to channels: 'edge'")
+    emitter.assert_message(
+        "Released 'test-snap' revision 10 to channels: 'edge' for 10% of users"
+    )
 
 
 #################


### PR DESCRIPTION
When using the 'progressive' feature, this was not reflected in the feedback from the snapcraft command.

Amended the output so you see what you did and you can be sure this is what was done.

Based on https://forum.snapcraft.io/t/feedback-on-progressive-percentage-in-snapcraft-output/49407 but with better wording: 'users' instead of 'clients'; this is more in line with snapcraft parlance.

Previous:
```
$ snapcraft release my-snap 12 stable --progressive 30
Released 'my-snap' revision 12 to channels: 'stable'
```

now:
```
$ snapcraft release my-snap 12 stable --progressive 30
Released 'my-snap' revision 12 to channels: 'stable' for 30% of users
```