### PR TITLE
fix: snapcraft try error shows effective base

### DIFF
--- a/snapcraft/commands/lifecycle.py
+++ b/snapcraft/commands/lifecycle.py
@@ -18,17 +18,16 @@
 
 import argparse
 import textwrap
-from typing import Any
+from typing import Any, cast
 
 import craft_application.commands
-import craft_application.errors
 from craft_cli import emit
 from typing_extensions import override
 
 import snapcraft.errors
 import snapcraft.pack
 from snapcraft import errors
-from snapcraft.utils import get_effective_base
+from snapcraft.models.project import Project
 
 
 class PackCommand(craft_application.commands.lifecycle.PackCommand):
@@ -122,17 +121,8 @@ class TryCommand(PackCommand):
         step_name: str | None = None,
         **kwargs: Any,
     ) -> None:
-        try:
-            project = self.services.get("project").get_raw()
-        except craft_application.errors.ProjectFileError:
-            project = {}
-
-        effective_base = get_effective_base(
-            base=project.get("base"),
-            build_base=project.get("build-base"),
-            project_type=project.get("type"),
-            name=project.get("name"),
-        )
+        project = cast(Project, self.services.get("project").get())
+        effective_base = project.get_effective_base()
 
         raise snapcraft.errors.FeatureNotImplemented(
             f'"snapcraft try" is not implemented for {effective_base}'

--- a/snapcraft/commands/lifecycle.py
+++ b/snapcraft/commands/lifecycle.py
@@ -125,7 +125,7 @@ class TryCommand(PackCommand):
         effective_base = project.get_effective_base()
 
         raise snapcraft.errors.FeatureNotImplemented(
-            f'"snapcraft try" is not implemented for {effective_base}'
+            f"'snapcraft try' is not implemented for {effective_base!r}"
         )
 
 

--- a/snapcraft/commands/lifecycle.py
+++ b/snapcraft/commands/lifecycle.py
@@ -21,12 +21,14 @@ import textwrap
 from typing import Any
 
 import craft_application.commands
+import craft_application.errors
 from craft_cli import emit
 from typing_extensions import override
 
 import snapcraft.errors
 import snapcraft.pack
 from snapcraft import errors
+from snapcraft.utils import get_effective_base
 
 
 class PackCommand(craft_application.commands.lifecycle.PackCommand):
@@ -120,8 +122,20 @@ class TryCommand(PackCommand):
         step_name: str | None = None,
         **kwargs: Any,
     ) -> None:
+        try:
+            project = self.services.get("project").get_raw()
+        except craft_application.errors.ProjectFileError:
+            project = {}
+
+        effective_base = get_effective_base(
+            base=project.get("base"),
+            build_base=project.get("build-base"),
+            project_type=project.get("type"),
+            name=project.get("name"),
+        )
+
         raise snapcraft.errors.FeatureNotImplemented(
-            '"snapcraft try" is not implemented for core24'
+            f'"snapcraft try" is not implemented for {effective_base}'
         )
 
 

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -99,16 +99,22 @@ def test_snap_command_error(mocker):
 
 
 @pytest.mark.usefixtures("emitter")
-def test_core24_try_command(tmp_path, fake_services):
+@pytest.mark.parametrize("base", ["core24", "core26"])
+def test_try_command(tmp_path, fake_services, base, mocker):
     parsed_args = argparse.Namespace(parts=[], output=tmp_path)
     cmd = lifecycle.TryCommand({"app": APP_METADATA, "services": fake_services})
+    mocker.patch.object(
+        fake_services.get("project"),
+        "get_raw",
+        return_value={"base": base},
+    )
 
     with pytest.raises(snapcraft.errors.FeatureNotImplemented) as raised:
         cmd.run(parsed_args=parsed_args)
 
     assert str(raised.value) == (
         'Command or feature not implemented: "snapcraft try" is not '
-        "implemented for core24"
+        f"implemented for {base}"
     )
 
 

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -100,15 +100,12 @@ def test_snap_command_error(mocker):
 
 @pytest.mark.usefixtures("emitter")
 @pytest.mark.parametrize("base", ["core24", "core26"])
-def test_try_command(tmp_path, fake_services, base, mocker):
+def test_try_command(tmp_path, fake_services, base, setup_project, default_project):
     parsed_args = argparse.Namespace(parts=[], output=tmp_path)
     cmd = lifecycle.TryCommand({"app": APP_METADATA, "services": fake_services})
-    mocker.patch.object(
-        fake_services.get("project"),
-        "get_raw",
-        return_value={"base": base},
+    setup_project(
+        fake_services, {**default_project.marshal(), "base": base}, write_project=True
     )
-
     with pytest.raises(snapcraft.errors.FeatureNotImplemented) as raised:
         cmd.run(parsed_args=parsed_args)
 

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -106,13 +106,12 @@ def test_try_command(tmp_path, fake_services, base, setup_project, default_proje
     setup_project(
         fake_services, {**default_project.marshal(), "base": base}, write_project=True
     )
-    with pytest.raises(snapcraft.errors.FeatureNotImplemented) as raised:
-        cmd.run(parsed_args=parsed_args)
 
-    assert str(raised.value) == (
-        'Command or feature not implemented: "snapcraft try" is not '
-        f"implemented for {base}"
-    )
+    expected = f"Command or feature not implemented: 'snapcraft try' is not implemented for {base!r}"
+    with pytest.raises(
+        snapcraft.errors.FeatureNotImplemented, match=re.escape(expected)
+    ):
+        cmd.run(parsed_args=parsed_args)
 
 
 def test_core24_pack(mocker, emitter, fake_services, tmp_path):


### PR DESCRIPTION
Fixes #6186

Use `get_effective_base()` to resolve the effective base before constructing the error message. 

### Changes

- `snapcraft/commands/lifecycle.py`: use `get_effective_base()` in `TryCommand.run()`
- `tests/unit/commands/test_lifecycle.py`: add tests for `core24` and `core26` using pytest.mark.paramterize

This change reads the project's base field via the project service so the error message accurately reports effective base the user configured.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
