### PR TITLE
test(spread): add missing symlink

### DIFF
--- a/tests/spread/core24/missing-test
+++ b/tests/spread/core24/missing-test
@@ -1,0 +1,1 @@
+../_common/missing-test


### PR DESCRIPTION
Test that shows spread panicking on a dangling symlink.