### PR TITLE
fix: create plug and layout files during pack

### DIFF
--- a/docs/reference/extensions/gpu-extension.rst
+++ b/docs/reference/extensions/gpu-extension.rst
@@ -212,8 +212,6 @@ The extension automatically adds parts to build and install the GPU wrapper and 
                     override-prime: |
                       craftctl default
                       ${CRAFT_PART_SRC}/bin/gpu-2604-cleanup mesa-2604
-                      # Workaround for https://bugs.launchpad.net/snapd/+bug/2055273
-                      mkdir -p "${CRAFT_PRIME}/gpu-2604"
 
     .. tab-item:: core24
         :sync: core24
@@ -425,8 +423,6 @@ This is the output before build, showing the expanded configuration:
                 +    override-prime: |
                 +      craftctl default
                 +      ${CRAFT_PART_SRC}/bin/gpu-2604-cleanup mesa-2604
-                +      # Workaround for https://bugs.launchpad.net/snapd/+bug/2055273
-                +      mkdir -p "${CRAFT_PRIME}/gpu-2604"
                 +
                   my-app:
                     plugin: nil

--- a/docs/release-notes/snapcraft-9-0.rst
+++ b/docs/release-notes/snapcraft-9-0.rst
@@ -209,8 +209,8 @@ Snapcraft 9.0.0
 ~~~~~~~~~~~~~~~~
 
 - `#6054`_ In the GNOME extension, fix a missing link to libproxy
-- `#6122`_ When using layouts and plugs with core26 and higher, create the target files
-  and directories during packing
+- `#6122`_ When using layouts and plugs with core26 and higher or a base snap, create
+  the target files and directories during packing
 
 
 Contributors

--- a/docs/release-notes/snapcraft-9-0.rst
+++ b/docs/release-notes/snapcraft-9-0.rst
@@ -209,8 +209,8 @@ Snapcraft 9.0.0
 ~~~~~~~~~~~~~~~~
 
 - `#6054`_ In the GNOME extension, fix a missing link to libproxy
-- `#6122`_ When using layouts and plugs with core26 and higher or a base snap, create
-  the target files and directories during packing
+- `#6122`_ Content interface mount targets are not created during build for snaps using
+  base core26+ or bare
 
 
 Contributors

--- a/docs/release-notes/snapcraft-9-0.rst
+++ b/docs/release-notes/snapcraft-9-0.rst
@@ -209,6 +209,8 @@ Snapcraft 9.0.0
 ~~~~~~~~~~~~~~~~
 
 - `#6054`_ In the GNOME extension, fix a missing link to libproxy
+- `#6122`_ When using layouts and plugs with core26 and higher, create the target files
+  and directories during packing
 
 
 Contributors
@@ -221,3 +223,4 @@ this release.
 
 
 .. _#6054: https://github.com/canonical/snapcraft/issues/6054
+.. _#6122: https://github.com/canonical/snapcraft/issues/6122

--- a/snapcraft/errors.py
+++ b/snapcraft/errors.py
@@ -18,6 +18,7 @@
 
 import os
 import subprocess
+from pathlib import Path
 
 from craft_cli import CraftError
 
@@ -229,4 +230,18 @@ class RemovedCommand(SnapcraftError):
             ),
             resolution=const.REMOVED_COMMAND_RESOLUTION.format(new=new_command),
             retcode=os.EX_USAGE,
+        )
+
+
+class SnapcraftPrecreationEscapesPrimeError(SnapcraftError):
+    """Error when a plug/layout precreation would've escaped the prime directory."""
+
+    def __init__(self, offending_path: str | Path) -> None:
+        super().__init__(
+            message=f"Could not package {str(offending_path)!r}",
+            details=(
+                "Path is not relative to snap contents, causing files to be created "
+                "outside of expected bounds."
+            ),
+            resolution="Ensure that the offending path is not referenced in any layout or plug definitions.",
         )

--- a/snapcraft/extensions/gpu_extension.py
+++ b/snapcraft/extensions/gpu_extension.py
@@ -203,8 +203,6 @@ class GPUExtension(Extension):
                     "override-prime": (
                         "craftctl default\n"
                         "${CRAFT_PART_SRC}/bin/gpu-2604-cleanup mesa-2604\n"
-                        "# Workaround for https://bugs.launchpad.net/snapd/+bug/2055273\n"
-                        'mkdir -p "${CRAFT_PRIME}/gpu-2604"'
                     ),
                 },
             }

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -1543,7 +1543,7 @@ class Project(models.Project):
     and directories outside of locations referenced by ``$SNAP`` or ``$SNAP_DATA``.
 
     For layouts that bind a file or directory in ``$SNAP``, the target path will be
-    created when packing the snap with core26 or higher.
+    created when packing the snap with core26 or higher, or bare bases.
 
     See :ref:`reference-layouts` for details.
 
@@ -1713,7 +1713,7 @@ class Project(models.Project):
     """Declares the snap's plugs.
 
     For content plugs that reference ``$SNAP``, the target path will be created when
-    packing the snap with core26 or higher.
+    packing the snap with core26 or higher, or bare bases.
 
     See :ref:`explanation-interfaces` for more information.
     """

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -1542,6 +1542,9 @@ class Project(models.Project):
     This helps when using pre-compiled binaries and libraries that expect to find files
     and directories outside of locations referenced by ``$SNAP`` or ``$SNAP_DATA``.
 
+    For layouts that bind a file or directory in ``$SNAP``, the target path will be
+    created when packing the snap with core26 or higher.
+
     See :ref:`reference-layouts` for details.
 
     **Values**
@@ -1708,6 +1711,9 @@ class Project(models.Project):
         ],
     )
     """Declares the snap's plugs.
+
+    For content plugs that reference ``$SNAP``, the target path will be created when
+    packing the snap with core26 or higher.
 
     See :ref:`explanation-interfaces` for more information.
     """

--- a/snapcraft/services/package.py
+++ b/snapcraft/services/package.py
@@ -83,6 +83,59 @@ class Package(PackageService):
             prime_dir=project_info.prime_dir,
         )
 
+        if self._project.get_effective_base() == "core26":
+            self._precreate_layout_targets()
+            self._precreate_plug_targets()
+
+    def _precreate_layout_targets(self) -> None:
+        if self._project.layout is None:
+            return
+
+        prime_dir = self._services.lifecycle.prime_dir
+        for target in self._project.layout:
+            # Layouts can either look like:
+            # real_path:
+            #   layout_type: snap_path
+            #
+            # or
+            #
+            # snap_path:
+            #   "type": layout_type
+            #
+            # Either way, we only care about the snap_path and layout_type.
+            prefix, _, _ = target.partition("/")
+            if prefix == "$SNAP":
+                path = target
+                _, ltype = next(iter(self._project.layout[target].items()))
+            else:
+                ltype, path = next(iter(self._project.layout[target].items()))
+
+            prefix, _, file = path.partition("/")
+            if prefix != "$SNAP":
+                continue
+            match ltype:
+                case "bind" | "tmpfs":
+                    (prime_dir / file).mkdir(0o0755, parents=True, exist_ok=True)
+                case "bind-file":
+                    file = prime_dir / file
+                    file.parent.mkdir(0o0755, parents=True, exist_ok=True)
+                    file.touch(0o0644)
+                case _:  # "symlink" requires no action and other values are raised elsewhere as a project file error
+                    pass
+
+    def _precreate_plug_targets(self) -> None:
+        if self._project.plugs is None:
+            return
+
+        prime_dir = self._services.lifecycle.prime_dir
+        plug_targets = [plug.target for plug in self._project.plugs.values()]
+        for target in plug_targets:
+            prefix, _, file = target.partition("/")
+            if prefix != "$SNAP":
+                continue
+
+            (prime_dir / file).mkdir(0o0755, parents=True, exist_ok=True)
+
     def _pack_components(self, dest: pathlib.Path) -> dict[str, pathlib.Path]:
         component_map: dict[str, pathlib.Path] = {}
         for component in self._project.get_component_names():

--- a/snapcraft/services/package.py
+++ b/snapcraft/services/package.py
@@ -110,14 +110,14 @@ class Package(PackageService):
             else:
                 ltype, path = next(iter(self._project.layout[target].items()))
 
-            prefix, _, file = path.partition("/")
+            prefix, _, suffix = path.partition("/")
             if prefix != "$SNAP":
                 continue
             match ltype:
                 case "bind" | "tmpfs":
-                    (prime_dir / file).mkdir(0o0755, parents=True, exist_ok=True)
+                    (prime_dir / suffix).mkdir(0o0755, parents=True, exist_ok=True)
                 case "bind-file":
-                    file = prime_dir / file
+                    file = prime_dir / suffix
                     file.parent.mkdir(0o0755, parents=True, exist_ok=True)
                     file.touch(0o0644)
                 case _:  # "symlink" requires no action and other values are raised elsewhere as a project file error

--- a/snapcraft/services/package.py
+++ b/snapcraft/services/package.py
@@ -25,6 +25,7 @@ from typing import cast
 
 from craft_application import PackageService
 from craft_application.util import strtobool
+from craft_cli import emit
 from typing_extensions import override
 
 from snapcraft import errors, linters, models, pack
@@ -100,6 +101,8 @@ class Package(PackageService):
         if self._project.layout is None:
             return
 
+        emit.debug("Pre-creating layout targets inside of snap")
+
         prime_dir = self._services.lifecycle.prime_dir
         for target in self._project.layout:
             # Layouts can either look like:
@@ -125,8 +128,16 @@ class Package(PackageService):
 
             match ltype:
                 case "bind" | "tmpfs":
+                    emit.debug(
+                        f"Layout target directory {path!r} maps to {str(file)!r} inside of the snap"
+                    )
+                    emit.debug(f"Creating {str(file)!r} in the prime directory")
                     (prime_dir / file).mkdir(0o0755, parents=True, exist_ok=True)
                 case "bind-file":
+                    emit.debug(
+                        f"Layout target file {path!r} maps to {str(file)!r} inside of the snap"
+                    )
+                    emit.debug(f"Creating {str(file)!r} in the prime directory")
                     snap_file = prime_dir / file
                     snap_file.parent.mkdir(0o0755, parents=True, exist_ok=True)
                     snap_file.touch(0o0644)
@@ -138,6 +149,8 @@ class Package(PackageService):
         if self._project.plugs is None:
             return
 
+        emit.debug("Pre-creating plug targets inside of snap")
+
         prime_dir = self._services.lifecycle.prime_dir
         plug_targets = [plug.target for plug in self._project.plugs.values()]
         for target in plug_targets:
@@ -145,6 +158,10 @@ class Package(PackageService):
             if file is None:
                 continue
 
+            emit.debug(
+                f"Plug target directory {target!r} maps to {str(file)!r} inside of the snap"
+            )
+            emit.debug(f"Creating {str(file)!r} in the prime directory")
             (prime_dir / file).mkdir(0o0755, parents=True, exist_ok=True)
 
     @staticmethod

--- a/snapcraft/services/package.py
+++ b/snapcraft/services/package.py
@@ -96,6 +96,7 @@ class Package(PackageService):
             self._precreate_plug_targets()
 
     def _precreate_layout_targets(self) -> None:
+        """Create layout targets ahead of time for snapd to avoid ENOENT errors."""
         if self._project.layout is None:
             return
 
@@ -132,6 +133,7 @@ class Package(PackageService):
                     pass
 
     def _precreate_plug_targets(self) -> None:
+        """Create plug targets ahead of time for snapd to avoid ENOENT errors."""
         if self._project.plugs is None:
             return
 

--- a/snapcraft/services/package.py
+++ b/snapcraft/services/package.py
@@ -146,7 +146,11 @@ class Package(PackageService):
 
         emit.debug("Pre-creating plug targets inside of snap")
 
-        plug_targets = [plug.target for plug in self._project.plugs.values()]
+        plug_targets = [
+            plug.target
+            for plug in self._project.plugs.values()
+            if plug.interface == "content"
+        ]
         for target in plug_targets:
             file = self._maybe_get_target_in_snap(target)
             if file is None:

--- a/snapcraft/services/package.py
+++ b/snapcraft/services/package.py
@@ -86,13 +86,7 @@ class Package(PackageService):
 
         # precreate content targets and layout sources when using core26+
         # and bare base snaps
-        if self._project.get_effective_base() not in [
-            "core",
-            "core18",
-            "core20",
-            "core22",
-            "core24",
-        ]:
+        if self._project.get_effective_base() not in ("core22", "core24"):
             self._precreate_layout_targets()
             self._precreate_plug_targets()
 

--- a/snapcraft/services/package.py
+++ b/snapcraft/services/package.py
@@ -119,16 +119,17 @@ class Package(PackageService):
             else:
                 ltype, path = next(iter(self._project.layout[target].items()))
 
-            prefix, _, suffix = path.partition("/")
-            if prefix != "$SNAP":
+            file = self._maybe_get_target_in_snap(path)
+            if file is None:
                 continue
+
             match ltype:
                 case "bind" | "tmpfs":
-                    (prime_dir / suffix).mkdir(0o0755, parents=True, exist_ok=True)
+                    (prime_dir / file).mkdir(0o0755, parents=True, exist_ok=True)
                 case "bind-file":
-                    file = prime_dir / suffix
-                    file.parent.mkdir(0o0755, parents=True, exist_ok=True)
-                    file.touch(0o0644)
+                    snap_file = prime_dir / file
+                    snap_file.parent.mkdir(0o0755, parents=True, exist_ok=True)
+                    snap_file.touch(0o0644)
                 case _:  # "symlink" requires no action and other values are raised elsewhere as a project file error
                     pass
 
@@ -140,11 +141,42 @@ class Package(PackageService):
         prime_dir = self._services.lifecycle.prime_dir
         plug_targets = [plug.target for plug in self._project.plugs.values()]
         for target in plug_targets:
-            prefix, _, file = target.partition("/")
-            if prefix != "$SNAP":
+            file = self._maybe_get_target_in_snap(target)
+            if file is None:
                 continue
 
             (prime_dir / file).mkdir(0o0755, parents=True, exist_ok=True)
+
+    @staticmethod
+    def _maybe_get_target_in_snap(path: str) -> pathlib.Path | None:
+        """Determine the path to create inside of a snap, if any, based on a layout or plug target.
+
+        Paths beginning with "/" or "$SNAP" will end up in the final artifact, as will relative
+        paths that do not begin with a variable (e.g. "foo", but not "$SNAP_DATA/foo").
+
+        If the path is only "/" or "$SNAP", this is just the snap root and should always
+        exist (no-op).
+
+        :param path: String path to investigate
+        :returns: A Path object that needs to be created, or None if nothing needs to be done."""
+        # Make explicit references to the snap root ($SNAP) relative
+        if path.startswith("$SNAP/"):
+            path = path.removeprefix("$SNAP/")
+
+        # Beginning with "/" is equivalent to beginning with "$SNAP". So likewise, make these relative too
+        while path.startswith("/"):
+            path = path.removeprefix("/")
+
+        # At this point, if the string is empty, it was just a reference to the snap root. This should
+        # always exist, so we can return early
+        if not path:
+            return None
+
+        # If any $s remain, this is a special path that shouldn't be handled
+        if "$" in path:
+            return None
+
+        return pathlib.Path(path)
 
     def _pack_components(self, dest: pathlib.Path) -> dict[str, pathlib.Path]:
         component_map: dict[str, pathlib.Path] = {}

--- a/snapcraft/services/package.py
+++ b/snapcraft/services/package.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import os
 import pathlib
 import shutil
-from typing import cast
+from typing import Literal, cast
 
 from craft_application import PackageService
 from craft_application.util import strtobool
@@ -98,23 +98,11 @@ class Package(PackageService):
 
         emit.debug("Pre-creating layout targets inside of snap")
 
-        for target in self._project.layout:
-            # Layouts can either look like:
-            # real_path:
-            #   layout_type: snap_path
-            #
-            # or
-            #
-            # snap_path:
-            #   "type": layout_type
-            #
-            # Either way, we only care about the snap_path and layout_type.
-            prefix, _, _ = target.partition("/")
-            if prefix == "$SNAP":
-                path = target
-                _, ltype = next(iter(self._project.layout[target].items()))
-            else:
-                ltype, path = next(iter(self._project.layout[target].items()))
+        for src, layout in self._project.layout.items():
+            result = self._parse_layout_target(src, layout)
+            if result is None:
+                continue
+            path, ltype = result
 
             file = self._maybe_get_target_in_snap(path)
             if file is None:
@@ -136,8 +124,6 @@ class Package(PackageService):
                     emit.debug(f"Creating {str(file)!r} in the prime directory")
                     to_create.parent.mkdir(0o0755, parents=True, exist_ok=True)
                     to_create.touch(0o0644)
-                case _:  # "symlink" requires no action and other values are raised elsewhere as a project file error
-                    pass
 
     def _precreate_plug_targets(self) -> None:
         """Create plug targets ahead of time for snapd to avoid ENOENT errors."""
@@ -163,6 +149,50 @@ class Package(PackageService):
             )
             emit.debug(f"Creating {str(file)!r} in the prime directory")
             to_create.mkdir(0o0755, parents=True, exist_ok=True)
+
+    @staticmethod
+    def _parse_layout_target(
+        src: str, layout: dict[Literal["symlink", "bind", "bind-file", "type"], str]
+    ) -> tuple[str, Literal["bind", "bind-file", "tmpfs"]] | None:
+        """Extracts the layout type and its str-path.
+
+        Below is an example of possible layout formats and what this method will
+        do with each.
+
+        layouts:
+            # Returns (<bind-mount sourcedir>, "bind")
+            <path>:
+                bind: <bind-mount sourcedir>
+
+            # Returns (<bind-mount sourcefile>, "bind-file")
+            <path>:
+                bind-file: <bind-mount sourcefile>
+
+            # Returns (<path>, "tmpfs")
+            <path>:
+                type: tmpfs
+
+            # Returns None
+            <path>:
+                symlink: <link-target>
+
+        This method will also return None for malformed layouts, though these should
+        always be caught by the project model validation before getting here.
+
+        :returns: A tuple of (str-path, layout-type). The returned path is neither sanitized
+            nor validated.
+        """
+        key, value = next(iter(layout.items()))
+
+        match key:
+            case "type":
+                if value == "tmpfs":
+                    return (src, "tmpfs")
+                return None
+            case "bind" | "bind-file":
+                return (value, key)
+            case _:
+                return None
 
     @staticmethod
     def _maybe_get_target_in_snap(path: str) -> pathlib.Path | None:

--- a/snapcraft/services/package.py
+++ b/snapcraft/services/package.py
@@ -83,7 +83,15 @@ class Package(PackageService):
             prime_dir=project_info.prime_dir,
         )
 
-        if self._project.get_effective_base() == "core26":
+        # precreate content targets and layout sources when using core26+
+        # and bare base snaps
+        if self._project.get_effective_base() not in [
+            "core",
+            "core18",
+            "core20",
+            "core22",
+            "core24",
+        ]:
             self._precreate_layout_targets()
             self._precreate_plug_targets()
 

--- a/snapcraft/services/package.py
+++ b/snapcraft/services/package.py
@@ -29,6 +29,7 @@ from craft_cli import emit
 from typing_extensions import override
 
 from snapcraft import errors, linters, models, pack
+from snapcraft.errors import SnapcraftPrecreationEscapesPrimeError
 from snapcraft.linters import LinterStatus
 from snapcraft.meta import component_yaml, snap_yaml
 from snapcraft.parts import extract_metadata as extract
@@ -97,7 +98,6 @@ class Package(PackageService):
 
         emit.debug("Pre-creating layout targets inside of snap")
 
-        prime_dir = self._services.lifecycle.prime_dir
         for target in self._project.layout:
             # Layouts can either look like:
             # real_path:
@@ -120,21 +120,22 @@ class Package(PackageService):
             if file is None:
                 continue
 
+            to_create = self._concat_with_prime_dir(file)
+
             match ltype:
                 case "bind" | "tmpfs":
                     emit.debug(
                         f"Layout target directory {path!r} maps to {str(file)!r} inside of the snap"
                     )
                     emit.debug(f"Creating {str(file)!r} in the prime directory")
-                    (prime_dir / file).mkdir(0o0755, parents=True, exist_ok=True)
+                    to_create.mkdir(0o0755, parents=True, exist_ok=True)
                 case "bind-file":
                     emit.debug(
                         f"Layout target file {path!r} maps to {str(file)!r} inside of the snap"
                     )
                     emit.debug(f"Creating {str(file)!r} in the prime directory")
-                    snap_file = prime_dir / file
-                    snap_file.parent.mkdir(0o0755, parents=True, exist_ok=True)
-                    snap_file.touch(0o0644)
+                    to_create.parent.mkdir(0o0755, parents=True, exist_ok=True)
+                    to_create.touch(0o0644)
                 case _:  # "symlink" requires no action and other values are raised elsewhere as a project file error
                     pass
 
@@ -145,18 +146,19 @@ class Package(PackageService):
 
         emit.debug("Pre-creating plug targets inside of snap")
 
-        prime_dir = self._services.lifecycle.prime_dir
         plug_targets = [plug.target for plug in self._project.plugs.values()]
         for target in plug_targets:
             file = self._maybe_get_target_in_snap(target)
             if file is None:
                 continue
 
+            to_create = self._concat_with_prime_dir(file)
+
             emit.debug(
                 f"Plug target directory {target!r} maps to {str(file)!r} inside of the snap"
             )
             emit.debug(f"Creating {str(file)!r} in the prime directory")
-            (prime_dir / file).mkdir(0o0755, parents=True, exist_ok=True)
+            to_create.mkdir(0o0755, parents=True, exist_ok=True)
 
     @staticmethod
     def _maybe_get_target_in_snap(path: str) -> pathlib.Path | None:
@@ -188,6 +190,21 @@ class Package(PackageService):
             return None
 
         return pathlib.Path(path)
+
+    def _concat_with_prime_dir(self, path: pathlib.Path) -> pathlib.Path:
+        """Concatenate a path onto the prime directory.
+
+        :returns: Concatenated path
+        :raises SnapcraftPrecreationEscapesPrimeError: When the resulting path is no longer relative
+            to the prime directory."""
+
+        prime_dir = self._services.lifecycle.prime_dir
+
+        result = prime_dir / path
+        if not result.resolve().is_relative_to(prime_dir):
+            raise SnapcraftPrecreationEscapesPrimeError(path)
+
+        return result
 
     def _pack_components(self, dest: pathlib.Path) -> dict[str, pathlib.Path]:
         component_map: dict[str, pathlib.Path] = {}

--- a/tests/unit/extensions/test_gpu_extension.py
+++ b/tests/unit/extensions/test_gpu_extension.py
@@ -231,10 +231,7 @@ def test_get_parts_snippet_core26(gpu_extension_core26):
             "source": "https://github.com/canonical/gpu-snap.git",
             "plugin": "nil",
             "override-prime": (
-                "craftctl default\n"
-                "${CRAFT_PART_SRC}/bin/gpu-2604-cleanup mesa-2604\n"
-                "# Workaround for https://bugs.launchpad.net/snapd/+bug/2055273\n"
-                'mkdir -p "${CRAFT_PRIME}/gpu-2604"'
+                "craftctl default\n${CRAFT_PART_SRC}/bin/gpu-2604-cleanup mesa-2604\n"
             ),
         },
     }

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -585,3 +585,25 @@ def test_precreate_plug_targets(
         file = tmp_path / "prime" / path
         assert file.stat().st_mode & 0o0755
         assert file.is_dir()
+
+
+@pytest.mark.parametrize(
+    ("in_path", "expected"),
+    [
+        pytest.param("$SNAP/foo", Path("foo"), id="simple"),
+        pytest.param("/foo", Path("foo"), id="absolute"),
+        pytest.param("foo", Path("foo"), id="relative"),
+        pytest.param("$SNAP/foo/bar", Path("foo/bar"), id="nested"),
+        pytest.param("$SNAP", None, id="no-op-base"),
+        pytest.param("/", None, id="no-op-absolute"),
+        pytest.param("$SNAP/", None, id="no-op-suffixed"),
+        pytest.param("///foo", Path("foo"), id="absolute-recursive"),
+        pytest.param("///", None, id="no-op-recursive"),
+        pytest.param("$SNAP_DATA/foo", None, id="no-op-unwanted"),
+    ],
+)
+def test_maybe_get_target_in_snap(
+    fake_services: ServiceFactory, in_path: str, expected: Path | None
+) -> None:
+    package_service = cast("Package", fake_services.get("package"))
+    assert package_service._maybe_get_target_in_snap(in_path) == expected

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -693,3 +693,33 @@ def test_concat_with_prime_dir(
 
     with expectation:
         package_service._concat_with_prime_dir(path)
+
+
+@pytest.mark.parametrize(
+    ("src", "layout", "expected"),
+    [
+        pytest.param(
+            "/opt/foo", {"bind": "$SNAP/foo"}, ("$SNAP/foo", "bind"), id="bind"
+        ),
+        pytest.param(
+            "/opt/foo/conf",
+            {"bind-file": "$SNAP/foo/conf"},
+            ("$SNAP/foo/conf", "bind-file"),
+            id="bind-file",
+        ),
+        pytest.param(
+            "/opt/foo/elsewhere",
+            {"symlink": "$SNAP/foo/elsewhere"},
+            None,
+            id="skip-symlink",
+        ),
+        pytest.param(
+            "$SNAP/scratch", {"type": "tmpfs"}, ("$SNAP/scratch", "tmpfs"), id="tmpfs"
+        ),
+        pytest.param("/opt/foo", {"type": "secret-other-thing"}, None, id="bad"),
+    ],
+)
+def test_parse_layout_target(
+    src: str, layout: dict[Any, str], expected: tuple[str, Any]
+) -> None:
+    assert Package._parse_layout_target(src, layout) == expected

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -27,7 +27,7 @@ import yaml
 from craft_application import ServiceFactory
 from pytest_mock import MockerFixture
 
-from snapcraft import __version__, const, linters, meta, models, pack
+from snapcraft import __version__, linters, meta, models, pack
 from snapcraft.meta import ExtractedMetadata
 from snapcraft.parts import extract_metadata, update_metadata
 from snapcraft.services import Package
@@ -363,7 +363,11 @@ def test_extra_project_updates_makes_targets_core26(
 
 
 @pytest.mark.parametrize(
-    "base", [base for base in const.CURRENT_BASES if base != "core26"]
+    "base",
+    [
+        "core22",
+        "core24",
+    ],
 )
 def test_extra_project_updates_no_make_targets_legacy(
     snapcraft_yaml: Callable[..., None],

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -345,8 +345,8 @@ def test_update_project_parse_info(
 
 
 def test_extra_project_updates_makes_targets_core26(
-    snapcraft_yaml: Callable[..., None],
-    setup_project: Callable[..., None],
+    snapcraft_yaml: Callable[..., Any],
+    setup_project: Callable[..., Any],
     fake_services: ServiceFactory,
     mocker: MockerFixture,
 ) -> None:
@@ -373,8 +373,8 @@ def test_extra_project_updates_makes_targets_core26(
     ],
 )
 def test_extra_project_updates_no_make_targets_legacy(
-    snapcraft_yaml: Callable[..., None],
-    setup_project: Callable[..., None],
+    snapcraft_yaml: Callable[..., Any],
+    setup_project: Callable[..., Any],
     fake_services: ServiceFactory,
     mocker: MockerFixture,
     base: str,
@@ -455,8 +455,8 @@ def test_extra_project_updates_no_make_targets_legacy(
     ],
 )
 def test_precreate_layout_targets(
-    snapcraft_yaml: Callable[..., None],
-    setup_project: Callable[..., None],
+    snapcraft_yaml: Callable[..., Any],
+    setup_project: Callable[..., Any],
     fake_services: ServiceFactory,
     layouts: dict[str, Any],
     expected_files: dict[str, list[Path]],
@@ -490,8 +490,8 @@ def test_precreate_layout_targets(
 
 
 def test_precreate_layout_targets_messages(
-    snapcraft_yaml: Callable[..., None],
-    setup_project: Callable[..., None],
+    snapcraft_yaml: Callable[..., Any],
+    setup_project: Callable[..., Any],
     fake_services: ServiceFactory,
     emitter: RecordingEmitter,
 ) -> None:
@@ -589,8 +589,8 @@ def test_precreate_layout_targets_messages(
     ],
 )
 def test_precreate_plug_targets(
-    snapcraft_yaml: Callable[..., None],
-    setup_project: Callable[..., None],
+    snapcraft_yaml: Callable[..., Any],
+    setup_project: Callable[..., Any],
     fake_services: ServiceFactory,
     plugs: dict[str, Any],
     expected_files: list[Path],
@@ -618,8 +618,8 @@ def test_precreate_plug_targets(
 
 
 def test_precreate_plug_targets_messages(
-    snapcraft_yaml: Callable[..., None],
-    setup_project: Callable[..., None],
+    snapcraft_yaml: Callable[..., Any],
+    setup_project: Callable[..., Any],
     fake_services: ServiceFactory,
     emitter: RecordingEmitter,
 ) -> None:

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -25,6 +25,7 @@ from typing import Any, cast
 import pytest
 import yaml
 from craft_application import ServiceFactory
+from craft_cli.pytest_plugin import RecordingEmitter
 from pytest_mock import MockerFixture
 
 from snapcraft import __version__, linters, meta, models, pack
@@ -486,6 +487,33 @@ def test_precreate_layout_targets(
         assert file.is_file()
 
 
+def test_precreate_layout_targets_messages(
+    snapcraft_yaml: Callable[..., None],
+    setup_project: Callable[..., None],
+    fake_services: ServiceFactory,
+    emitter: RecordingEmitter,
+) -> None:
+    layout = {
+        "/opt/foo": {"bind": "$SNAP/foo"},
+        "/usr/lib/foo/ids": {"bind-file": "$SNAP/foo/gpu-2404.ids"},
+    }
+    project = snapcraft_yaml(layout=layout, base="core26")
+    setup_project(fake_services, project)
+    package_service = cast("Package", fake_services.get("package"))
+
+    package_service._precreate_layout_targets()
+
+    emitter.assert_debug("Pre-creating layout targets inside of snap")
+    emitter.assert_debug(
+        "Layout target directory '$SNAP/foo' maps to 'foo' inside of the snap"
+    )
+    emitter.assert_debug("Creating 'foo' in the prime directory")
+    emitter.assert_debug(
+        "Layout target file '$SNAP/foo/gpu-2404.ids' maps to 'foo/gpu-2404.ids' inside of the snap"
+    )
+    emitter.assert_debug("Creating 'foo/gpu-2404.ids' in the prime directory")
+
+
 @pytest.mark.parametrize(
     ("plugs", "expected_files"),
     [
@@ -585,6 +613,31 @@ def test_precreate_plug_targets(
         file = tmp_path / "prime" / path
         assert file.stat().st_mode & 0o0755
         assert file.is_dir()
+
+
+def test_precreate_plug_targets_messages(
+    snapcraft_yaml: Callable[..., None],
+    setup_project: Callable[..., None],
+    fake_services: ServiceFactory,
+    emitter: RecordingEmitter,
+) -> None:
+    plugs = {
+        "usb": {
+            "interface": "content",
+            "target": "$SNAP/usb",
+        }
+    }
+    project = snapcraft_yaml(plugs=plugs, base="core26")
+    setup_project(fake_services, project)
+    package_service = cast("Package", fake_services.get("package"))
+
+    package_service._precreate_plug_targets()
+
+    emitter.assert_debug("Pre-creating plug targets inside of snap")
+    emitter.assert_debug(
+        "Plug target directory '$SNAP/usb' maps to 'usb' inside of the snap"
+    )
+    emitter.assert_debug("Creating 'usb' in the prime directory")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -18,6 +18,7 @@
 
 import datetime
 from collections.abc import Callable
+from contextlib import AbstractContextManager, nullcontext
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, cast
@@ -29,6 +30,7 @@ from craft_cli.pytest_plugin import RecordingEmitter
 from pytest_mock import MockerFixture
 
 from snapcraft import __version__, linters, meta, models, pack
+from snapcraft.errors import SnapcraftPrecreationEscapesPrimeError
 from snapcraft.meta import ExtractedMetadata
 from snapcraft.parts import extract_metadata, update_metadata
 from snapcraft.services import Package
@@ -660,3 +662,34 @@ def test_maybe_get_target_in_snap(
 ) -> None:
     package_service = cast("Package", fake_services.get("package"))
     assert package_service._maybe_get_target_in_snap(in_path) == expected
+
+
+@pytest.mark.parametrize(
+    ("path", "expectation"),
+    [
+        pytest.param(Path("foo"), nullcontext(), id="simple"),
+        pytest.param(Path("foo", "bar"), nullcontext(), id="parts"),
+        pytest.param(
+            Path("..", "..", ".."),
+            pytest.raises(SnapcraftPrecreationEscapesPrimeError),
+            id="far-back",
+        ),
+        pytest.param(
+            Path("..", "stage"),
+            pytest.raises(SnapcraftPrecreationEscapesPrimeError),
+            id="to-stage",
+        ),
+    ],
+)
+def test_concat_with_prime_dir(
+    fake_services: ServiceFactory,
+    default_project: models.Project,
+    setup_project: Callable[..., Any],
+    path: Path,
+    expectation: AbstractContextManager,
+) -> None:
+    setup_project(fake_services, default_project.marshal(), write_project=True)
+    package_service = cast("Package", fake_services.get("package"))
+
+    with expectation:
+        package_service._concat_with_prime_dir(path)

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -17,15 +17,20 @@
 """Tests for the Snapcraft Package service."""
 
 import datetime
+from collections.abc import Callable
 from pathlib import Path
 from textwrap import dedent
+from typing import Any, cast
 
 import pytest
 import yaml
+from craft_application import ServiceFactory
+from pytest_mock import MockerFixture
 
-from snapcraft import __version__, linters, meta, models, pack
+from snapcraft import __version__, const, linters, meta, models, pack
 from snapcraft.meta import ExtractedMetadata
 from snapcraft.parts import extract_metadata, update_metadata
+from snapcraft.services import Package
 
 
 def test_pack(default_project, fake_services, setup_project, mocker):
@@ -334,3 +339,245 @@ def test_update_project_parse_info(
         assets_dir=in_project_path / "snap",
         prime_dir=tmp_path / "prime",
     )
+
+
+def test_extra_project_updates_makes_targets_core26(
+    snapcraft_yaml: Callable[..., None],
+    setup_project: Callable[..., None],
+    fake_services: ServiceFactory,
+    mocker: MockerFixture,
+) -> None:
+    setup_project(fake_services, snapcraft_yaml(base="core26"))
+    package_service = fake_services.get("package")
+    mock_precreate_layout = mocker.patch.object(
+        package_service, "_precreate_layout_targets"
+    )
+    mock_precreate_plugs = mocker.patch.object(
+        package_service, "_precreate_plug_targets"
+    )
+
+    package_service.update_project()
+
+    mock_precreate_layout.assert_called_once()
+    mock_precreate_plugs.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "base", [base for base in const.CURRENT_BASES if base != "core26"]
+)
+def test_extra_project_updates_no_make_targets_legacy(
+    snapcraft_yaml: Callable[..., None],
+    setup_project: Callable[..., None],
+    fake_services: ServiceFactory,
+    mocker: MockerFixture,
+    base: str,
+) -> None:
+    setup_project(fake_services, snapcraft_yaml(base=base))
+    package_service = fake_services.get("package")
+    mock_precreate_layout = mocker.patch.object(
+        package_service, "_precreate_layout_targets"
+    )
+    mock_precreate_plugs = mocker.patch.object(
+        package_service, "_precreate_plug_targets"
+    )
+
+    package_service.update_project()
+
+    mock_precreate_layout.assert_not_called()
+    mock_precreate_plugs.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("layouts", "expected_files"),
+    [
+        pytest.param({}, {"dirs": [], "files": []}, id="none"),
+        pytest.param(
+            {
+                "/opt/foo": {"bind": "$SNAP/foo"},
+            },
+            {"dirs": [Path("foo")], "files": []},
+            id="dir",
+        ),
+        pytest.param(
+            {"/usr/lib/foo": {"bind": "$SNAP/foo/gpu-2404"}},
+            {"dirs": [Path("foo"), Path("foo", "gpu-2404")], "files": []},
+            id="dir-recursive",
+        ),
+        pytest.param(
+            {"/usr/lib/foo/ids": {"bind-file": "$SNAP/foo/gpu-2404.ids"}},
+            {
+                "dirs": [Path("foo")],
+                "files": [Path("foo", "gpu-2404.ids")],
+            },
+            id="file",
+        ),
+        pytest.param(
+            {
+                "/var/lib/bar": {"bind": "$SNAP_DATA/bar"},
+            },
+            {
+                "dirs": [],
+                "files": [],
+            },
+            id="no-op",
+        ),
+        pytest.param(
+            {
+                "$SNAP/baz": {"type": "tmpfs"},
+            },
+            {
+                "dirs": [Path("baz")],
+                "files": [],
+            },
+            id="path-in-key",
+        ),
+        pytest.param(
+            {
+                "/opt/foo": {"bind": "$SNAP/foo"},
+                "/usr/lib/foo": {"bind": "$SNAP/foo/gpu-2404"},
+                "/usr/lib/foo/ids": {"bind-file": "$SNAP/foo/gpu-2404.ids"},
+                "/var/lib/bar": {"bind": "$SNAP_DATA/bar"},
+                "$SNAP/baz": {"type": "tmpfs"},
+            },
+            {
+                "dirs": [Path("foo"), Path("foo", "gpu-2404"), Path("baz")],
+                "files": [Path("foo", "gpu-2404.ids")],
+            },
+            id="all",
+        ),
+    ],
+)
+def test_precreate_layout_targets(
+    snapcraft_yaml: Callable[..., None],
+    setup_project: Callable[..., None],
+    fake_services: ServiceFactory,
+    layouts: dict[str, Any],
+    expected_files: dict[str, list[Path]],
+    tmp_path: Path,
+) -> None:
+    project = snapcraft_yaml(layout=layouts, base="core26")
+    setup_project(fake_services, project)
+    package_service = cast(Package, fake_services.get("package"))
+
+    package_service._precreate_layout_targets()
+
+    prime_dir = fake_services.lifecycle.prime_dir
+    prime_dir.mkdir(0o755, exist_ok=True)
+
+    primed_files = [
+        file.relative_to(tmp_path / "prime") for file in prime_dir.rglob("*")
+    ]
+
+    all_expected_files = [*expected_files["dirs"], *expected_files["files"]]
+    assert sorted(primed_files) == sorted(all_expected_files)
+
+    for path in expected_files["dirs"]:
+        file = tmp_path / "prime" / path
+        assert file.stat().st_mode & 0o0755
+        assert file.is_dir()
+
+    for path in expected_files["files"]:
+        file = tmp_path / "prime" / path
+        assert file.stat().st_mode & 0o0644
+        assert file.is_file()
+
+
+@pytest.mark.parametrize(
+    ("plugs", "expected_files"),
+    [
+        pytest.param({}, [], id="none"),
+        pytest.param(
+            {
+                "usb": {
+                    "interface": "content",
+                    "target": "$SNAP/usb",
+                },
+            },
+            [Path("usb")],
+            id="one",
+        ),
+        pytest.param(
+            {
+                "usb": {
+                    "interface": "content",
+                    "target": "$SNAP/usb",
+                },
+                "serial": {
+                    "interface": "content",
+                    "target": "$SNAP/serial",
+                },
+            },
+            [Path("usb"), Path("serial")],
+            id="two",
+        ),
+        pytest.param(
+            {
+                "hdmi": {
+                    "interface": "content",
+                    "target": "$SNAP/hdmi/2.1",
+                },
+            },
+            [Path("hdmi"), Path("hdmi", "2.1")],
+            id="recursive",
+        ),
+        pytest.param(
+            {
+                "flash-drive": {
+                    "interface": "content",
+                    "target": "$SNAP_DATA/flash-drive",
+                },
+            },
+            [],
+            id="no-op",
+        ),
+        pytest.param(
+            {
+                "usb": {
+                    "interface": "content",
+                    "target": "$SNAP/usb",
+                },
+                "serial": {
+                    "interface": "content",
+                    "target": "$SNAP/serial",
+                },
+                "hdmi": {
+                    "interface": "content",
+                    "target": "$SNAP/hdmi/2.1",
+                },
+                "flash-drive": {
+                    "interface": "content",
+                    "target": "$SNAP_DATA/flash-drive",
+                },
+            },
+            [Path("usb"), Path("serial"), Path("hdmi"), Path("hdmi", "2.1")],
+            id="all",
+        ),
+    ],
+)
+def test_precreate_plug_targets(
+    snapcraft_yaml: Callable[..., None],
+    setup_project: Callable[..., None],
+    fake_services: ServiceFactory,
+    plugs: dict[str, Any],
+    expected_files: list[Path],
+    tmp_path: Path,
+) -> None:
+    project = snapcraft_yaml(plugs=plugs, base="core26")
+    setup_project(fake_services, project)
+    package_service = cast(Package, fake_services.get("package"))
+
+    package_service._precreate_plug_targets()
+
+    prime_dir = fake_services.lifecycle.prime_dir
+    prime_dir.mkdir(0o755, exist_ok=True)
+
+    primed_files = [
+        file.relative_to(tmp_path / "prime") for file in prime_dir.rglob("*")
+    ]
+
+    assert sorted(primed_files) == sorted(expected_files)
+
+    for path in expected_files:
+        file = tmp_path / "prime" / path
+        assert file.stat().st_mode & 0o0755
+        assert file.is_dir()

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -480,12 +480,12 @@ def test_precreate_layout_targets(
 
     for path in expected_files["dirs"]:
         file = tmp_path / "prime" / path
-        assert file.stat().st_mode & 0o0755
+        assert file.stat().st_mode & 0o0755 == 0o0755
         assert file.is_dir()
 
     for path in expected_files["files"]:
         file = tmp_path / "prime" / path
-        assert file.stat().st_mode & 0o0644
+        assert file.stat().st_mode & 0o0644 == 0o0644
         assert file.is_file()
 
 
@@ -613,7 +613,7 @@ def test_precreate_plug_targets(
 
     for path in expected_files:
         file = tmp_path / "prime" / path
-        assert file.stat().st_mode & 0o0755
+        assert file.stat().st_mode & 0o0755 == 0o0755
         assert file.is_dir()
 
 


### PR DESCRIPTION
Pre-create the directories and files for plugs and layouts during the pack step if packing on core26+.

Closes #6122.
SNAPCRAFT-1330

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
