### PR TITLE
fix: gpu: mesa-2404 references in cleanup step

### DIFF
--- a/docs/reference/extensions/gpu-extension.rst
+++ b/docs/reference/extensions/gpu-extension.rst
@@ -236,7 +236,7 @@ The extension automatically adds parts to build and install the GPU wrapper and 
                     plugin: nil
                     override-prime: |
                       craftctl default
-                      ${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-core24
+                      ${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-2404
                       # Workaround for https://bugs.launchpad.net/snapd/+bug/2055273
                       mkdir -p "${CRAFT_PRIME}/gpu-2404"
 
@@ -485,7 +485,7 @@ This is the output before build, showing the expanded configuration:
                 +    plugin: nil
                 +    override-prime: |
                 +      craftctl default
-                +      ${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-core24
+                +      ${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-2404
                 +      # Workaround for https://bugs.launchpad.net/snapd/+bug/2055273
                 +      mkdir -p "${CRAFT_PRIME}/gpu-2404"
                 +

--- a/snapcraft/extensions/gpu_extension.py
+++ b/snapcraft/extensions/gpu_extension.py
@@ -181,7 +181,7 @@ class GPUExtension(Extension):
                     "plugin": "nil",
                     "override-prime": (
                         "craftctl default\n"
-                        "${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-core24\n"
+                        "${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-2404\n"
                         "# Workaround for https://bugs.launchpad.net/snapd/+bug/2055273\n"
                         'mkdir -p "${CRAFT_PRIME}/gpu-2404"'
                     ),

--- a/tests/unit/extensions/test_gnome.py
+++ b/tests/unit/extensions/test_gnome.py
@@ -438,7 +438,7 @@ def test_get_parts_snippet_core24(gnome_extension_core24):
             "plugin": "nil",
             "override-prime": (
                 "craftctl default\n"
-                "${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-core24\n"
+                "${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-2404\n"
                 "# Workaround for https://bugs.launchpad.net/snapd/+bug/2055273\n"
                 'mkdir -p "${CRAFT_PRIME}/gpu-2404"'
             ),

--- a/tests/unit/extensions/test_gpu_extension.py
+++ b/tests/unit/extensions/test_gpu_extension.py
@@ -188,7 +188,7 @@ def test_get_parts_snippet(gpu_extension_core24):
             "plugin": "nil",
             "override-prime": (
                 "craftctl default\n"
-                "${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-core24\n"
+                "${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-2404\n"
                 "# Workaround for https://bugs.launchpad.net/snapd/+bug/2055273\n"
                 'mkdir -p "${CRAFT_PRIME}/gpu-2404"'
             ),

--- a/tests/unit/extensions/test_kde_neon.py
+++ b/tests/unit/extensions/test_kde_neon.py
@@ -699,7 +699,7 @@ def test_get_parts_snippet_core24(kde_neon_extension_core24):
             "plugin": "nil",
             "override-prime": (
                 "craftctl default\n"
-                "${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-core24\n"
+                "${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-2404\n"
                 "# Workaround for https://bugs.launchpad.net/snapd/+bug/2055273\n"
                 'mkdir -p "${CRAFT_PRIME}/gpu-2404"'
             ),
@@ -758,7 +758,7 @@ def test_get_parts_snippet_with_external_sdk_different_channel(
                 "plugin": "nil",
                 "override-prime": (
                     "craftctl default\n"
-                    "${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-core24\n"
+                    "${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-2404\n"
                     "# Workaround for https://bugs.launchpad.net/snapd/+bug/2055273\n"
                     'mkdir -p "${CRAFT_PRIME}/gpu-2404"'
                 ),

--- a/tests/unit/extensions/test_kde_neon_6.py
+++ b/tests/unit/extensions/test_kde_neon_6.py
@@ -776,7 +776,7 @@ def test_get_parts_snippet_core24(kde_neon_6_extension_core24):
             "plugin": "nil",
             "override-prime": (
                 "craftctl default\n"
-                "${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-core24\n"
+                "${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-2404\n"
                 "# Workaround for https://bugs.launchpad.net/snapd/+bug/2055273\n"
                 'mkdir -p "${CRAFT_PRIME}/gpu-2404"'
             ),
@@ -835,7 +835,7 @@ def test_get_parts_snippet_with_external_sdk_different_channel(
                 "plugin": "nil",
                 "override-prime": (
                     "craftctl default\n"
-                    "${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-core24\n"
+                    "${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-2404\n"
                     "# Workaround for https://bugs.launchpad.net/snapd/+bug/2055273\n"
                     'mkdir -p "${CRAFT_PRIME}/gpu-2404"'
                 ),

--- a/tests/unit/extensions/test_kde_neon_qt6.py
+++ b/tests/unit/extensions/test_kde_neon_qt6.py
@@ -617,7 +617,7 @@ def test_get_parts_snippet_core24(kde_neon_qt6_extension_core24):
             "plugin": "nil",
             "override-prime": (
                 "craftctl default\n"
-                "${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-core24\n"
+                "${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-2404\n"
                 "# Workaround for https://bugs.launchpad.net/snapd/+bug/2055273\n"
                 'mkdir -p "${CRAFT_PRIME}/gpu-2404"'
             ),
@@ -665,7 +665,7 @@ def test_get_parts_snippet_with_external_sdk_different_channel(
                 "plugin": "nil",
                 "override-prime": (
                     "craftctl default\n"
-                    "${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-core24\n"
+                    "${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-2404\n"
                     "# Workaround for https://bugs.launchpad.net/snapd/+bug/2055273\n"
                     'mkdir -p "${CRAFT_PRIME}/gpu-2404"'
                 ),


### PR DESCRIPTION
`mesa-core24` was a copy-paste, the snap is `mesa-2404`

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
