### PR TITLE
fix(extensions/gpu): drop XErrorDB layout entry for core26

### DIFF
--- a/docs/reference/extensions/gpu-extension.rst
+++ b/docs/reference/extensions/gpu-extension.rst
@@ -393,10 +393,6 @@ This is the output before build, showing the expanded configuration:
                 +    target: $SNAP/gpu-2604
                 +    default-provider: mesa-2604
                 +
-                +layout:
-                +  /usr/share/X11/XErrorDB:
-                +    bind-file: $SNAP/gpu-2604/X11/XErrorDB
-                +
                 apps:
                   my-gpu-app:
                     command: usr/bin/my-gpu-app

--- a/snapcraft/extensions/gpu_extension.py
+++ b/snapcraft/extensions/gpu_extension.py
@@ -79,10 +79,6 @@ class GPUExtension(Extension):
         },
     }
 
-    _GPU_2604_LAYOUTS: dict[str, Any] = {
-        "/usr/share/X11/XErrorDB": {"bind-file": "$SNAP/gpu-2604/X11/XErrorDB"},
-    }
-
     @staticmethod
     @override
     def get_supported_bases() -> tuple[str, ...]:
@@ -130,7 +126,6 @@ class GPUExtension(Extension):
         if base == "core26":
             return {
                 "plugs": dict(self._GPU_2604_PLUG),
-                "layout": dict(self._GPU_2604_LAYOUTS),
             }
         raise AssertionError(f"Unsupported base: {base}")
 

--- a/tests/unit/extensions/test_gpu_extension.py
+++ b/tests/unit/extensions/test_gpu_extension.py
@@ -161,11 +161,6 @@ def test_get_root_snippet_core26(gpu_extension_core26):
                 "default-provider": "mesa-2604",
             },
         },
-        "layout": {
-            "/usr/share/X11/XErrorDB": {
-                "bind-file": "$SNAP/gpu-2604/X11/XErrorDB",
-            },
-        },
     }
 
 


### PR DESCRIPTION
The actual XErrorDB is shipped by core26 now. No need to install one through layouts.

See https://github.com/canonical/core-base/pull/432 for reference.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
