### PR TITLE
fix(register): link to snap registration docs

### DIFF
--- a/snapcraft/commands/names.py
+++ b/snapcraft/commands/names.py
@@ -59,6 +59,10 @@ _MESSAGE_REGISTER_CONFIRM = textwrap.dedent(
 )
 _MESSAGE_REGISTER_SUCCESS = "Registered {!r}"
 _MESSAGE_REGISTER_NO = "Snap name {!r} not registered"
+_MESSAGE_REGISTER_DOCUMENTATION = (
+    "Go to https://documentation.ubuntu.com/snapcraft/stable/how-to/publishing/"
+    "register-a-snap/ for more information on registering a snap."
+)
 
 
 def _set_nil(value: str):
@@ -115,6 +119,8 @@ class StoreRegisterCommand(AppCommand):
                 _MESSAGE_REGISTER_PRIVATE.format(snap_name),
                 permanent=True,
             )
+        emit.progress(_MESSAGE_REGISTER_DOCUMENTATION, permanent=True)
+
         if parsed_args.yes or utils.confirm_with_user(
             _MESSAGE_REGISTER_CONFIRM.format(snap_name)
         ):

--- a/tests/unit/commands/test_names.py
+++ b/tests/unit/commands/test_names.py
@@ -114,6 +114,28 @@ def test_register_yes(emitter, fake_store_register, fake_app_config):
 
 
 @pytest.mark.usefixtures("memory_keyring")
+def test_register_shows_registration_documentation(
+    emitter, fake_store_register, fake_app_config
+):
+    cmd = commands.StoreRegisterCommand(fake_app_config)
+
+    cmd.run(
+        argparse.Namespace(
+            store_id=None, private=False, yes=True, **{"snap-name": "test-snap"}
+        )
+    )
+
+    fake_store_register.assert_called_once_with(
+        ANY, "test-snap", is_private=False, store_id=None
+    )
+    emitter.assert_progress(
+        "Go to https://documentation.ubuntu.com/snapcraft/stable/how-to/publishing/"
+        "register-a-snap/ for more information on registering a snap.",
+        permanent=True,
+    )
+
+
+@pytest.mark.usefixtures("memory_keyring")
 def test_register_no(
     emitter, fake_confirmation_prompt, fake_store_register, fake_app_config
 ):
@@ -126,7 +148,7 @@ def test_register_no(
     )
 
     assert fake_store_register.mock_calls == []
-    emitter.assert_messages(["Snap name 'test-snap' not registered"])
+    emitter.assert_message("Snap name 'test-snap' not registered")
     assert fake_confirmation_prompt.mock_calls == [
         call(
             dedent(
@@ -170,9 +192,7 @@ def test_register_private(emitter, fake_store_register, fake_app_config):
         ),
         permanent=True,
     )
-    emitter.assert_message(
-        "Snap name 'test-snap' not registered",
-    )
+    emitter.assert_message("Snap name 'test-snap' not registered")
 
 
 @pytest.mark.usefixtures("memory_keyring")


### PR DESCRIPTION
Fixes #5042.

This adds a link from the `snapcraft register` command output to the RTD snap registration how-to.

The documentation link is shown after the registration flow whether the user confirms registration, uses `--yes`, or declines the confirmation prompt.

Validation:
- `pytest -q tests/unit/commands/test_names.py -k register -rs`
- `ruff check snapcraft/commands/names.py tests/unit/commands/test_names.py`