### PR TITLE
fix: show metrics for snaps with no data

### DIFF
--- a/snapcraft/commands/metrics.py
+++ b/snapcraft/commands/metrics.py
@@ -131,7 +131,7 @@ class StoreMetricsCommand(AppCommand):
         rows: list[list[str | int]] = []
 
         status = results.status
-        if status == "NO_DATA":
+        if status == "NO DATA":
             # No data available, return empty list.
             return rows
         if status == "FAIL":

--- a/snapcraft/models/metrics.py
+++ b/snapcraft/models/metrics.py
@@ -81,7 +81,7 @@ class Series(models.CraftBaseModel):
 class Metric(models.CraftBaseModel):
     """Single point of metrics for a snap."""
 
-    status: Literal["OK", "FAIL", "NO_DATA"]
+    status: Literal["OK", "FAIL", "NO DATA"]
     """Status of metrics retrieval."""
 
     snap_id: str

--- a/tests/unit/commands/test_metrics.py
+++ b/tests/unit/commands/test_metrics.py
@@ -153,7 +153,7 @@ def test_metrics_no_data(
     fake_response = MetricsResponse(
         metrics=[
             Metric(
-                status="NO_DATA",
+                status="NO DATA",
                 snap_id="test-snap-id",
                 metric_name=MetricName.DAILY_DEVICE_CHANGE,
                 buckets=[],

--- a/tests/unit/models/test_metrics.py
+++ b/tests/unit/models/test_metrics.py
@@ -68,7 +68,7 @@ def test_series_invalid_currently_released(currently_released):
 @pytest.mark.parametrize(
     "series", [[], [{"name": "s1", "values": []}], [{"name": "s2", "values": ["v1"]}]]
 )
-@pytest.mark.parametrize("status", ["OK", "FAIL", "NO_DATA"])
+@pytest.mark.parametrize("status", ["OK", "FAIL", "NO DATA"])
 def test_metric_results(buckets, series, status):
     results = Metric(
         status=status,
@@ -167,7 +167,7 @@ def test_metrics_results_unmarshal_no_data():
                 "metric_name": "weekly_installed_base_by_channel",
                 "series": [],
                 "snap_id": "test-snap-id",
-                "status": "NO_DATA",
+                "status": "NO DATA",
             }
         ]
     }
@@ -177,7 +177,7 @@ def test_metrics_results_unmarshal_no_data():
     assert metrics_results == MetricsResponse(
         metrics=[
             Metric(
-                status="NO_DATA",
+                status="NO DATA",
                 snap_id="test-snap-id",
                 metric_name=MetricName.WEEKLY_INSTALLED_BASE_BY_CHANNEL,
                 buckets=[],


### PR DESCRIPTION
Fixes a typo from #6207. I missed it during local testing because I didn't test on a snap without metrics.

This was [caught by the store tests](https://github.com/canonical/snapcraft/actions/runs/25003757177/job/73221983107#step:5:1839) (I missed the failure when merging).

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
