### PR TITLE
docs: finalize Snapcraft 9 release notes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -202,7 +202,6 @@ exclude_patterns = [
     "common/craft-parts/reference/step_execution_environment.rst",
     "common/craft-parts/reference/step_output_directories.rst",
     "common/craft-parts/reference/plugins/maven_plugin.rst",
-    "common/craft-parts/reference/plugins/maven_use_plugin.rst",
     "common/craft-parts/reference/plugins/poetry_plugin.rst",
     "common/craft-parts/reference/plugins/python_plugin.rst",
     "common/craft-parts/reference/plugins/python_v2_plugin.rst",

--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -29,6 +29,7 @@ This section contains an in-depth description of the plugins available in Snapcr
     /common/craft-parts/reference/plugins/make_plugin
     plugins/matter_sdk_plugin
     plugins/maven_plugin
+    /common/craft-parts/reference/plugins/maven_use_plugin
     /common/craft-parts/reference/plugins/meson_plugin
     /common/craft-parts/reference/plugins/nil_plugin
     /common/craft-parts/reference/plugins/npm_plugin

--- a/docs/release-notes/index.rst
+++ b/docs/release-notes/index.rst
@@ -7,8 +7,10 @@ This page lists the notes for past releases of Snapcraft, which summarize new fe
 bug fixes and backwards-incompatible changes in each version. It also contains the
 release and support policies for Snapcraft.
 
-Upcoming releases
------------------
+.. _current-releases:
+
+Current releases
+----------------
 
 Snapcraft 9
 ~~~~~~~~~~~
@@ -16,13 +18,12 @@ Snapcraft 9
 - :ref:`Snapcraft 9.0 <release-9.0>`
 
 
-.. _current-releases:
-
-Current releases
-----------------
-
 Snapcraft 8
 ~~~~~~~~~~~
+
+Snapcraft 8 is available for building core20 snaps. When building for higher bases,
+use Snapcraft 9. See :ref:`how-to-set-up-snapcraft-multiple-instances` for more
+information.
 
 - :ref:`Snapcraft 8.14 <release-8.14>`
 - :ref:`Snapcraft 8.13 <release-8.13>`
@@ -33,22 +34,20 @@ Snapcraft 8
 - :ref:`Snapcraft 8.8 <release-8.8>`
 - :ref:`Snapcraft 8.7 <release-8.7>`
 
-
-Snapcraft 7
-~~~~~~~~~~~
-
-Snapcraft 7 is available for building core18 snaps. When building for higher bases,
-use Snapcraft 8. See :ref:`how-to-set-up-snapcraft-multiple-instances` for more
-information.
-
-- :ref:`Snapcraft 7.5.8 <changelog-7-5-8>`
+For a list of the latest major version of Snapcraft that supports a particular
+base, see the :ref:`Base snaps reference <base-snap-reference>`.
 
 
 Past releases
 -------------
 
-For a list of the latest major version of Snapcraft that supports a particular
-base, see the :ref:`Base snaps reference <base-snap-reference>`.
+Snapcraft 7
+~~~~~~~~~~~
+
+Snapcraft 7 is available for building core18 snaps.
+
+- :ref:`Snapcraft 7.5.8 <changelog-7-5-8>`
+
 
 Snapcraft 6
 ~~~~~~~~~~~

--- a/docs/release-notes/snapcraft-9-0.rst
+++ b/docs/release-notes/snapcraft-9-0.rst
@@ -69,18 +69,20 @@ The new :ref:`craft_parts_bazel_plugin` has been added for building Bazel applic
 ``npm-use`` plugin
 ~~~~~~~~~~~~~~~~~~
 
-The new :ref:`craft_parts_npm_use_plugin` has been added. This plugin builds npm
-applications from local dependencies.
+The new :ref:`craft_parts_npm_use_plugin` has been added. This plugin exports NPM
+tarballs to a local directory.
 
 Additionally, the :ref:`craft_parts_npm_plugin` plugin gained support for the
-``self-contained`` build attribute, which enables parts using the ``npm-use`` plugin to
-use local dependencies.
+``self-contained`` build attribute.
+
+Together, these changes enable NPM parts to build from local sources.
 
 ``maven-use`` plugin
 ~~~~~~~~~~~~~~~~~~~~
 
-The new :ref:`craft_parts_maven_use_plugin` has been added. This plugin builds Maven
-applications from local dependencies.
+The new :ref:`craft_parts_maven_use_plugin` has been added. This plugin deploys Maven
+artifacts to a local repository, enabling other Maven parts to build from local
+sources.
 
 
 Build on a compatible architecture

--- a/docs/release-notes/snapcraft-9-0.rst
+++ b/docs/release-notes/snapcraft-9-0.rst
@@ -65,7 +65,6 @@ Stable .NET extensions
 The :ref:`reference-dotnet-extensions` are now stable and no longer require
 the ``SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS`` environment variable.
 
-
 Bazel plugin
 ~~~~~~~~~~~~
 
@@ -90,15 +89,6 @@ A :ref:`craft_parts_maven_use_plugin` has been added. This plugin deploys Maven
 artifacts to a local repository, enabling other Maven parts to build from local
 sources.
 
-
-Build on a compatible architecture
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Snapcraft can now build a snap inside a build provider running a different but compatible
-architecture. Set the ``CRAFT_BUILD_ON`` environment variable to the desired
-Debian architecture when invoking the build.
-
-For example, this can be used to build an ARMHF snap on an ARM64 host.
 
 Minor features
 --------------

--- a/docs/release-notes/snapcraft-9-0.rst
+++ b/docs/release-notes/snapcraft-9-0.rst
@@ -1,11 +1,12 @@
+.. meta::
+    :description: Learn about the new features, changes, and fixes introduced in Snapcraft 9.0.
+
 .. _release-9.0:
 
 Snapcraft 9.0 release notes
 ===========================
 
-.. add date before releasing
-
-(upcoming release)
+7 May 2026
 
 Learn about the new features, changes, and fixes introduced in Snapcraft 9.0.
 
@@ -15,6 +16,76 @@ Requirements and compatibility
 See :ref:`reference-system-requirements` for information on the minimum hardware and
 installed software.
 
+
+What's new
+----------
+
+Snapcraft 9.0 brings the following features, integrations, and improvements.
+
+
+Stable support for core26
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Core26 snaps can now be built without ``build-base: devel`` or ``grade: devel``. As a
+result, they are eligible for publication to candidate and stable channels in the Snap
+Store.
+
+The :ref:`Change from core24 to core26 <how-to-change-from-core24-to-core26>` guide
+describes the steps for migrating an existing Snapcraft project to core26.
+
+GPU extension
+~~~~~~~~~~~~~
+
+The new :ref:`reference-gpu-extension` has been added for core22 and higher snaps,
+which provides hardware-accelerated graphics support for applications that need OpenGL,
+Vulkan, and other GPU capabilities.
+
+GPU linter
+~~~~~~~~~~
+
+A new linter has been added for snaps that need GPU support.
+If a snap includes GPU libraries, the linter suggests using a GPU content snap.
+
+:ref:`Use the GPU linter <how-to-use-the-gpu-linter>` describes how to address issues
+flagged by the linter.
+
+Stable .NET extensions
+~~~~~~~~~~~~~~~~~~~~~~
+
+The :ref:`reference-dotnet-extensions` are now stable and no longer require
+using the ``SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS`` environment variable.
+
+
+Bazel plugin
+~~~~~~~~~~~~
+
+The new :ref:`craft_parts_bazel_plugin` has been added for building Bazel applications.
+
+``npm-use`` plugin
+~~~~~~~~~~~~~~~~~~
+
+The new :ref:`craft_parts_npm_use_plugin` has been added. This plugin builds npm
+applications from local dependencies.
+
+Additionally, the :ref:`craft_parts_npm_plugin` plugin gained support for the
+``self-contained`` build attribute, which enables parts using the ``npm-use`` plugin to
+use local dependencies.
+
+``maven-use`` plugin
+~~~~~~~~~~~~~~~~~~~~
+
+The new :ref:`craft_parts_maven_use_plugin` has been added. This plugin builds Maven
+applications from local dependencies.
+
+
+Build on a compatible architecture
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Snapcraft can now build a snap inside a provider running a different but compatible
+architecture. Set the ``CRAFT_BUILD_ON`` environment variable to the desired
+architecture when invoking the build.
+
+For example, this can be used to build an ARMHF snap on an ARM64 host.
 
 Minor features
 --------------
@@ -54,6 +125,25 @@ The :ref:`metadata linter <how-to-use-the-metadata-linter>` no longer checks for
 :ref:`Project.donation` key, as this key was generally rarely set and was silenced more
 often than not.
 
+Gradle plugin improvements
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Gradle daemon is now disabled by default when using the
+:ref:`craft_parts_gradle_plugin`. You can control this behavior with the new
+``gradle-use-daemon`` key.
+
+The Gradle plugin also gained support for the ``self-contained`` build attribute,
+which enables parts using the :ref:`craft_parts_maven_use_plugin` to use local
+dependencies.
+
+7zip support
+~~~~~~~~~~~~
+
+Parts can now source 7zip files ending in either ``.7zip`` or ``.7z``. Previously, 7zip
+files had to end in ``.7zip``.
+
+Additionally, 7zip files are now documented in the :ref:`source-type <PartSpec.source_type>`
+key in the project file reference.
 
 Backwards-incompatible changes
 ------------------------------
@@ -157,6 +247,13 @@ instances of ``snapcraftctl`` in your scripts.
 
 Core22 and core24 aren't affected by this change.
 
+Removed forward slashes in core26 part names
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Core26 snaps can no longer use forward slashes (/) in part names. The
+:ref:`migration guide <how-to-change-from-core24-to-core26>` describes how to update
+parts with forward slashes in their name.
+
 Removed support for Windows
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -210,14 +307,21 @@ Fixed bugs and issues
 
 The following issues have been resolved in Snapcraft 9.0.
 
-.. _release-9.0.0-fixes:
+.. _release-notes-fixes-9.0.0:
 
 Snapcraft 9.0.0
 ~~~~~~~~~~~~~~~~
 
-- `#6054`_ In the GNOME extension, fix a missing link to libproxy
-- `#6122`_ Content interface mount targets are not created during build for snaps using
-  base core26+ or bare
+- `#6122 <https://github.com/canonical/snapcraft/issues/6122>`__ Content interface mount
+  targets weren't created during build for snaps using base core26+ or bare.
+- `#6054 <https://github.com/canonical/snapcraft/issues/6054>`__ The GNOME
+  extension was missing symlink to libproxy.
+- `#6148 <https://github.com/canonical/snapcraft/issues/6148>`__ Dependencies in the
+  core26 snap were included when staging packages.
+- `craft-parts#1444 <https://github.com/canonical/craft-parts/issues/1444>`__ Stage and
+  build packages with versioned dependencies couldn't be resolved.
+- `craft-parts#1492 <https://github.com/canonical/craft-parts/issues/1492>`__ The
+  :ref:`craft_parts_poetry_plugin` didn't work for core26 snaps.
 
 
 Contributors
@@ -226,8 +330,31 @@ Contributors
 We would like to express a big thank you to all the people who contributed to
 this release.
 
-.. add contributors before releasing
 
-
-.. _#6054: https://github.com/canonical/snapcraft/issues/6054
-.. _#6122: https://github.com/canonical/snapcraft/issues/6122
+:literalref:`@Amanlem <https://github.com/Amanlem>`,
+:literalref:`@asanvaq <https://github.com/asanvaq>`,
+:literalref:`@atandrewlee <https://github.com/atandrewlee>`,
+:literalref:`@bboozzoo <https://github.com/bboozzoo>`,
+:literalref:`@bepri <https://github.com/bepri>`,
+:literalref:`@brlin-tw <https://github.com/brlin-tw>`,
+:literalref:`@canon-cat <https://github.com/canon-cat>`,
+:literalref:`@cmatsuoka <https://github.com/cmatsuoka>`,
+:literalref:`@EddyPronk <https://github.com/EddyPronk>`,
+:literalref:`@ethandcosta <https://github.com/ethandcosta>`,
+:literalref:`@gcomneno <https://github.com/gcomneno>`,
+:literalref:`@Guillaumebeuzeboc <https://github.com/Guillaumebeuzeboc>`,
+:literalref:`@jahn-junior <https://github.com/jahn-junior>`,
+:literalref:`@jawadsalwati <https://github.com/jawadsalwati>`,
+:literalref:`@lengau <https://github.com/lengau>`,
+:literalref:`@mateusrodrigues <https://github.com/mateusrodrigues>`,
+:literalref:`@mbeijen <https://github.com/mbeijen>`,
+:literalref:`@medubelko <https://github.com/medubelko>`,
+:literalref:`@mr-cal <https://github.com/mr-cal>`,
+:literalref:`@Namrathabp <https://github.com/Namrathabp>`,
+:literalref:`@PraaneshSelvaraj <https://github.com/PraaneshSelvaraj>`,
+:literalref:`@Saviq <https://github.com/Saviq>`,
+:literalref:`@smethnani <https://github.com/smethnani>`,
+:literalref:`@steinbro <https://github.com/steinbro>`,
+:literalref:`@tigarmo <https://github.com/tigarmo>`,
+:literalref:`@toroleapinc <https://github.com/toroleapinc>`,
+and :literalref:`@vedantdaterao <https://github.com/vedantdaterao>`

--- a/docs/release-notes/snapcraft-9-0.rst
+++ b/docs/release-notes/snapcraft-9-0.rst
@@ -30,15 +30,20 @@ Core26 snaps can now be built without ``build-base: devel`` or ``grade: devel``.
 result, they are eligible for publication to candidate and stable channels in the Snap
 Store.
 
-The :ref:`Change from core24 to core26 <how-to-change-from-core24-to-core26>` guide
-describes the steps for migrating an existing Snapcraft project to core26.
+The :ref:`how-to-change-from-core24-to-core26` guide describes the steps for migrating
+an existing Snapcraft project to core26.
 
 GPU extension
 ~~~~~~~~~~~~~
 
+Previously, snaps had to use a desktop extension, such as the GNOME extension, to
+get GPU support even when they didn't need full desktop support. This increased the
+complexity and build time of snaps.
+
 The new :ref:`reference-gpu-extension` has been added for core22 and higher snaps,
 which provides hardware-accelerated graphics support for applications that need OpenGL,
-Vulkan, and other GPU capabilities.
+Vulkan, and other GPU capabilities. Snaps that only need GPU support can use this
+extension instead of a desktop extension.
 
 GPU linter
 ~~~~~~~~~~
@@ -46,8 +51,8 @@ GPU linter
 A new linter has been added for snaps that need GPU support.
 If a snap includes GPU libraries, the linter suggests using a GPU content snap.
 
-:ref:`Use the GPU linter <how-to-use-the-gpu-linter>` describes how to address issues
-flagged by the linter.
+The :ref:`how-to-use-the-gpu-linter` guide describes how to address issues flagged by
+the linter.
 
 Stable .NET extensions
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/release-notes/snapcraft-9-0.rst
+++ b/docs/release-notes/snapcraft-9-0.rst
@@ -53,7 +53,8 @@ GPU linter
 ~~~~~~~~~~
 
 A new linter has been added for snaps that need GPU libraries.
-If a snap includes GPU libraries, the linter suggests using a GPU content snap.
+If a snap stages GPU libraries via the :ref:`stage-packages <PartSpec.stage_packages>`
+key, the linter suggests using a GPU content snap instead.
 
 The :ref:`how-to-use-the-gpu-linter` guide describes how to address issues flagged by
 the linter.
@@ -95,7 +96,7 @@ Build on a compatible architecture
 
 Snapcraft can now build a snap inside a build provider running a different but compatible
 architecture. Set the ``CRAFT_BUILD_ON`` environment variable to the desired
-architecture when invoking the build.
+Debian architecture when invoking the build.
 
 For example, this can be used to build an ARMHF snap on an ARM64 host.
 

--- a/docs/release-notes/snapcraft-9-0.rst
+++ b/docs/release-notes/snapcraft-9-0.rst
@@ -53,7 +53,7 @@ GPU linter
 ~~~~~~~~~~
 
 A new linter has been added for snaps that need GPU libraries.
-If a snap stages GPU libraries via the :ref:`stage-packages <PartSpec.stage_packages>`
+If a snap stages GPU libraries with the :ref:`stage-packages <PartSpec.stage_packages>`
 key, the linter suggests using a GPU content snap instead.
 
 The :ref:`how-to-use-the-gpu-linter` guide describes how to address issues flagged by

--- a/docs/release-notes/snapcraft-9-0.rst
+++ b/docs/release-notes/snapcraft-9-0.rst
@@ -23,32 +23,36 @@ What's new
 Snapcraft 9.0 brings the following features, integrations, and improvements.
 
 
-Stable support for core26
-~~~~~~~~~~~~~~~~~~~~~~~~~
+Support for core26
+~~~~~~~~~~~~~~~~~~
 
-Core26 snaps can now be built without ``build-base: devel`` or ``grade: devel``. As a
-result, they are eligible for publication to candidate and stable channels in the Snap
+Snapcraft now supports building snaps with the core26 base. Core26 is stable and
+recommended for all new snaps.
+
+If you're currently using core24, you can migrate by following the
+:ref:`how-to-change-from-core24-to-core26` guide.
+
+If you were already building experimental core26 snaps, you can drop
+``build-base: devel`` or ``grade: devel`` from your project file. As a result, your
+snaps will be eligible for publication to candidate and stable channels in the Snap
 Store.
-
-The :ref:`how-to-change-from-core24-to-core26` guide describes the steps for migrating
-an existing Snapcraft project to core26.
 
 GPU extension
 ~~~~~~~~~~~~~
 
-Previously, snaps had to use a desktop extension, such as the GNOME extension, to
-get GPU support even when they didn't need full desktop support. This increased the
-complexity and build time of snaps.
+Snaps support hardware-accelerated graphics like OpenGL and Vulkan, but accessing GPU
+libraries usually requires a full desktop extension, increasing complexity and build
+time.
 
-The new :ref:`reference-gpu-extension` has been added for core22 and higher snaps,
-which provides hardware-accelerated graphics support for applications that need OpenGL,
-Vulkan, and other GPU capabilities. Snaps that only need GPU support can use this
-extension instead of a desktop extension.
+A :ref:`reference-gpu-extension` has been added for core22 and higher snaps, which
+provides hardware-accelerated graphics support for apps. If your snap used a desktop
+extension like GNOME as a workaround for accessing GPU capabilities, replace it with
+this new extension.
 
 GPU linter
 ~~~~~~~~~~
 
-A new linter has been added for snaps that need GPU support.
+A new linter has been added for snaps that need GPU libraries.
 If a snap includes GPU libraries, the linter suggests using a GPU content snap.
 
 The :ref:`how-to-use-the-gpu-linter` guide describes how to address issues flagged by
@@ -58,29 +62,30 @@ Stable .NET extensions
 ~~~~~~~~~~~~~~~~~~~~~~
 
 The :ref:`reference-dotnet-extensions` are now stable and no longer require
-using the ``SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS`` environment variable.
+the ``SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS`` environment variable.
 
 
 Bazel plugin
 ~~~~~~~~~~~~
 
-The new :ref:`craft_parts_bazel_plugin` has been added for building Bazel applications.
+The :ref:`craft_parts_bazel_plugin` is now available for parts that need the Bazel
+build system.
 
-``npm-use`` plugin
-~~~~~~~~~~~~~~~~~~
+npm Use plugin
+~~~~~~~~~~~~~~
 
-The new :ref:`craft_parts_npm_use_plugin` has been added. This plugin exports NPM
+A :ref:`craft_parts_npm_use_plugin` has been added. This plugin exports npm
 tarballs to a local directory.
 
 Additionally, the :ref:`craft_parts_npm_plugin` plugin gained support for the
 ``self-contained`` build attribute.
 
-Together, these changes enable NPM parts to build from local sources.
+Together, these changes enable npm parts to build from local sources.
 
-``maven-use`` plugin
-~~~~~~~~~~~~~~~~~~~~
+Maven Use plugin
+~~~~~~~~~~~~~~~~
 
-The new :ref:`craft_parts_maven_use_plugin` has been added. This plugin deploys Maven
+A :ref:`craft_parts_maven_use_plugin` has been added. This plugin deploys Maven
 artifacts to a local repository, enabling other Maven parts to build from local
 sources.
 
@@ -88,7 +93,7 @@ sources.
 Build on a compatible architecture
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Snapcraft can now build a snap inside a provider running a different but compatible
+Snapcraft can now build a snap inside a build provider running a different but compatible
 architecture. Set the ``CRAFT_BUILD_ON`` environment variable to the desired
 architecture when invoking the build.
 
@@ -139,9 +144,8 @@ The Gradle daemon is now disabled by default when using the
 :ref:`craft_parts_gradle_plugin`. You can control this behavior with the new
 ``gradle-use-daemon`` key.
 
-The Gradle plugin also gained support for the ``self-contained`` build attribute,
-which enables parts using the :ref:`craft_parts_maven_use_plugin` to use local
-dependencies.
+The plugin also supports the ``self-contained`` build attribute, so that parts using the
+:ref:`craft_parts_maven_use_plugin` can use local dependencies.
 
 7zip support
 ~~~~~~~~~~~~

--- a/snapcraft/application.py
+++ b/snapcraft/application.py
@@ -137,8 +137,6 @@ class Snapcraft(Application):
         """Register per application plugins when initializing."""
         super()._register_default_plugins()
 
-        craft_parts.plugins.unregister("maven-use")
-
         if self._use_craftapp_lib:
             # core22 uses dotnet v1
             # core24 and newer uses dotnet v2

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -322,16 +322,6 @@ def test_application_dotnet_registered(
     assert craft_parts.plugins.get_plugin_class("dotnet") == expected_plugin
 
 
-def test_application_maven_use_not_registered(snapcraft_yaml):
-    """maven-use plugin is disabled."""
-    snapcraft_yaml(base="core24")
-    app = application.create_app()
-
-    app._register_default_plugins()
-
-    assert "maven-use" not in craft_parts.plugins.get_registered_plugins()
-
-
 def test_default_command_integrated(monkeypatch, mocker, new_dir):
     """Test that for core24 projects we accept "pack" as the default command."""
 


### PR DESCRIPTION
Finalizes the Snapcraft 9 release notes.

Also enables the maven-use plugin.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [x] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [x] I've updated the relevant release notes.
