### PR TITLE
fix: only precreate content plug targets

### DIFF
--- a/snapcraft/services/package.py
+++ b/snapcraft/services/package.py
@@ -133,11 +133,13 @@ class Package(PackageService):
 
         emit.debug("Pre-creating plug targets inside of snap")
 
-        plug_targets = [
-            plug.target
-            for plug in self._project.plugs.values()
-            if isinstance(plug, ContentPlug) and plug.interface == "content"
-        ]
+        plug_targets = []
+        for name, plug in self._project.plugs.items():
+            if isinstance(plug, ContentPlug) and plug.interface == "content":
+                plug_targets.append(plug.target)
+            elif name == "content":
+                plug_targets.append(cast("dict[str, str]", plug)["target"])
+
         for target in plug_targets:
             file = self._maybe_get_target_in_snap(target)
             if file is None:

--- a/snapcraft/services/package.py
+++ b/snapcraft/services/package.py
@@ -32,6 +32,7 @@ from snapcraft import errors, linters, models, pack
 from snapcraft.errors import SnapcraftPrecreationEscapesPrimeError
 from snapcraft.linters import LinterStatus
 from snapcraft.meta import component_yaml, snap_yaml
+from snapcraft.models import ContentPlug
 from snapcraft.parts import extract_metadata as extract
 from snapcraft.parts import update_metadata as update
 from snapcraft.parts.setup_assets import setup_assets
@@ -135,7 +136,7 @@ class Package(PackageService):
         plug_targets = [
             plug.target
             for plug in self._project.plugs.values()
-            if plug.interface == "content"
+            if isinstance(plug, ContentPlug) and plug.interface == "content"
         ]
         for target in plug_targets:
             file = self._maybe_get_target_in_snap(target)

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -564,6 +564,7 @@ def test_precreate_layout_targets_messages(
             [],
             id="no-op",
         ),
+        pytest.param({"bluetooth": {"private": True}}, [], id="non-content"),
         pytest.param(
             {
                 "usb": {
@@ -582,6 +583,7 @@ def test_precreate_layout_targets_messages(
                     "interface": "content",
                     "target": "$SNAP_DATA/flash-drive",
                 },
+                "bluetooth": {"private": True},
             },
             [Path("usb"), Path("serial"), Path("hdmi"), Path("hdmi", "2.1")],
             id="all",

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -556,6 +556,15 @@ def test_precreate_layout_targets_messages(
         ),
         pytest.param(
             {
+                "content": {
+                    "target": "$SNAP/aux",
+                },
+            },
+            [Path("aux")],
+            id="in-name",
+        ),
+        pytest.param(
+            {
                 "flash-drive": {
                     "interface": "content",
                     "target": "$SNAP_DATA/flash-drive",
@@ -583,9 +592,18 @@ def test_precreate_layout_targets_messages(
                     "interface": "content",
                     "target": "$SNAP_DATA/flash-drive",
                 },
+                "content": {
+                    "target": "$SNAP/aux",
+                },
                 "bluetooth": {"private": True},
             },
-            [Path("usb"), Path("serial"), Path("hdmi"), Path("hdmi", "2.1")],
+            [
+                Path("usb"),
+                Path("serial"),
+                Path("hdmi"),
+                Path("hdmi", "2.1"),
+                Path("aux"),
+            ],
             id="all",
         ),
     ],


### PR DESCRIPTION
Fixes an issue where certain plug formats (such as the one below) would cause an error during the precreation of plug targets.

```yaml
plugs:
  my-plug:
    private: true
```

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
