### PR TITLE
fix(test): correct match string in try test

### DIFF
--- a/tests/spread/core24/try/task.yaml
+++ b/tests/spread/core24/try/task.yaml
@@ -1,4 +1,4 @@
 summary: Test "snapcraft try" in core24
 
 execute: |
-  snapcraft try 2>&1 | grep -q -e '"snapcraft try" is not implemented for core24'
+  snapcraft try 2>&1 | MATCH "'snapcraft try' is not implemented for 'core24'"


### PR DESCRIPTION
Fixes a test string that became invalidated in #6193 

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
