### PR TITLE
docs: gpu: move to new documentation location

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -268,7 +268,7 @@ intersphinx_mapping = {
     "charmcraft": ("https://documentation.ubuntu.com/charmcraft/stable/", None),
     "rockcraft": ("https://documentation.ubuntu.com/rockcraft/stable/", None),
     "starflow": ("https://canonical-starflow.readthedocs-hosted.com", None),
-    "ubuntu-frame": ("https://canonical-ubuntu-frame-documentation.readthedocs-hosted.com/24", None),
+    "ubuntu-frame": ("https://ubuntu.com/frame/docs/24/", None),
 }
 
 # Block Intersphinx from looking up external sources with internal references. In other

--- a/snapcraft/linters/gpu_linter.py
+++ b/snapcraft/linters/gpu_linter.py
@@ -26,9 +26,9 @@ from snapcraft.elf import elf_utils
 from .base import Linter, LinterIssue, LinterResult
 
 _HELP_URLS = {
-    "core22": "https://canonical-ubuntu-frame-documentation.readthedocs-hosted.com/how-to/use-snap-graphics-on-base-core22/",
-    "core24": "https://canonical-ubuntu-frame-documentation.readthedocs-hosted.com/how-to/use-snap-graphics-on-base-core24/",
-    "core26": "https://canonical-ubuntu-frame-documentation.readthedocs-hosted.com/how-to/use-snap-graphics/",
+    "core22": "https://ubuntu.com/frame/docs/22/how-to/use-snap-graphics/",
+    "core24": "https://ubuntu.com/frame/docs/24/how-to/use-snap-graphics/",
+    "core26": "https://ubuntu.com/frame/docs/26/how-to/use-snap-graphics/",
 }
 
 _CORE22_PATTERNS = {

--- a/tests/unit/linters/test_gpu_linter.py
+++ b/tests/unit/linters/test_gpu_linter.py
@@ -118,10 +118,7 @@ def test_gpu_linter_core22(mocker, new_dir, mock_elf_files, files, expected_coun
             issue.text
             == "GPU support library should be provided by a content interface."
         )
-        assert (
-            issue.url
-            == "https://canonical-ubuntu-frame-documentation.readthedocs-hosted.com/how-to/use-snap-graphics-on-base-core22/"
-        )
+        assert issue.url == "https://ubuntu.com/frame/docs/22/how-to/use-snap-graphics/"
 
 
 @pytest.mark.parametrize(
@@ -263,10 +260,7 @@ def test_gpu_linter_core24(mocker, new_dir, mock_elf_files, files, expected_coun
             issue.text
             == "GPU support library should be provided by a content interface."
         )
-        assert (
-            issue.url
-            == "https://canonical-ubuntu-frame-documentation.readthedocs-hosted.com/how-to/use-snap-graphics-on-base-core24/"
-        )
+        assert issue.url == "https://ubuntu.com/frame/docs/24/how-to/use-snap-graphics/"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Docs now migrated.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
