### PR TITLE
docs: fix old link in changelog

### DIFF
--- a/docs/release-notes/changelog.rst
+++ b/docs/release-notes/changelog.rst
@@ -1547,7 +1547,7 @@ For a complete list of commits, check out the `8.0.0`_ release on GitHub.
 
 .. _canonical-sphinx: https://github.com/canonical/canonical-sphinx
 .. _Craft Application: https://github.com/canonical/craft-application
-.. _gpu 2404 interface docs: https://mir-server.io/docs/the-gpu-2404-snap-interface#heading--consuming-the-interface
+.. _gpu 2404 interface docs: https://ubuntu.com/frame/docs/24/how-to/use-snap-graphics/#consuming-the-interface
 .. _Matter: https://csa-iot.org/all-solutions/matter/
 .. _Matter on Ubuntu: https://canonical-matter.readthedocs-hosted.com/en/latest/
 .. _Releases page: https://github.com/canonical/snapcraft/releases


### PR DESCRIPTION
The old link was being complained about by the link checker. It redirected just fine, but the heading anchor had changed and so it was still flagging it as a bad link.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
