### PR TITLE
fix(utils): only unsquash metadata files

### DIFF
--- a/snapcraft/utils.py
+++ b/snapcraft/utils.py
@@ -426,7 +426,9 @@ def get_data_from_snap_file(snap_path: Path) -> tuple[dict, dict | None]:
     :raises SnapcraftError: If the snap file cannot be read.
     :raises FileNotFoundError: If snap.yaml doesn't exist.
     """
-    with unsquash_snap(snap_path) as snap_dir:
+    with unsquash_snap(
+        snap_path, extra_args=["meta/snap.yaml", "snap/manifest.yaml"]
+    ) as snap_dir:
         snap_yaml_path = snap_dir / "meta" / "snap.yaml"
         with snap_yaml_path.open() as yaml_file:
             snap_yaml = yaml.safe_load(yaml_file)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -545,6 +545,10 @@ class TestGetDataFromSnapFile:
 
         snap_yaml, manifest_yaml = utils.get_data_from_snap_file(fake_snap_file)
 
+        mock_unsquash.assert_called_once_with(
+            fake_snap_file,
+            extra_args=["meta/snap.yaml", "snap/manifest.yaml"],
+        )
         assert snap_yaml == self.SNAP_YAML_CONTENT
         assert manifest_yaml is None
 
@@ -559,8 +563,17 @@ class TestGetDataFromSnapFile:
 
         snap_yaml, manifest_yaml = utils.get_data_from_snap_file(fake_snap_file)
 
+        mock_unsquash.assert_called_once_with(
+            fake_snap_file,
+            extra_args=["meta/snap.yaml", "snap/manifest.yaml"],
+        )
         assert snap_yaml == self.SNAP_YAML_CONTENT
         assert manifest_yaml == self.MANIFEST_YAML_CONTENT
+
+    def test_snap_yaml_missing(self, mock_unsquash, snap_dir, fake_snap_file):
+        """Error if the snap is missing a snap.yaml file."""
+        with pytest.raises(FileNotFoundError):
+            utils.get_data_from_snap_file(fake_snap_file)
 
     def test_error_on_unsquash_failure(self, mocker, fake_snap_file):
         """Error when unsquashfs fails."""


### PR DESCRIPTION
Fixes the `get_data_from_snap_file` to only unsquash metadata files.  This was an oversight when the upload command was [switched](https://github.com/canonical/snapcraft/commit/5864b582e495a4dd5778fda764b4023eb31304bc#diff-8d486fec1b7c44f763f9dba5efd65edbbedf4e3cb7386fb1b31e9dde23a78bb4R118) from the legacy [`get_data_from_snap_file`](https://github.com/canonical/snapcraft/blob/e02708489f0882cafde18b22bcfe90ddf226d13c/snapcraft_legacy/_store.py#L60-L66).

Fixes #6206 
(SNAPCRAFT-1337) ...heh, LEET

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
