### PR TITLE
feat: recommend Snapcraft 9.x for core22, core24, and core26 bases

### DIFF
--- a/snapcraft/application.py
+++ b/snapcraft/application.py
@@ -88,7 +88,7 @@ def _get_base_warning_for_base(base: str) -> None:
     """Emit a warning to use Snapcraft 9.x for core22, core24, and core26 bases."""
     match base:
         case "core22" | "core24" | "core26":
-            emit.message(
+            emit.warning(
                 f"Base {base!r} is supported in Snapcraft 9.x. "
                 "It is recommended to upgrade to Snapcraft 9.x via the 'latest/stable' channel "
                 "to benefit from the latest bug fixes and performance improvements."

--- a/snapcraft/application.py
+++ b/snapcraft/application.py
@@ -84,6 +84,19 @@ def _get_esm_error_for_base(base: str) -> None:
     )
 
 
+def _get_base_warning_for_base(base: str) -> None:
+    """Emit a warning to use Snapcraft 9.x for core22, core24, and core26 bases."""
+    match base:
+        case "core22" | "core24" | "core26":
+            emit.message(
+                f"Base {base!r} is supported in Snapcraft 9.x. "
+                "It is recommended to upgrade to Snapcraft 9.x via the 'latest/stable' channel "
+                "to benefit from the latest bug fixes and performance improvements."
+            )
+        case _:
+            return
+
+
 class Snapcraft(Application):
     """Snapcraft application definition."""
 
@@ -174,6 +187,7 @@ class Snapcraft(Application):
             )
             _get_esm_error_for_base(effective_base)
             self._ensure_remote_build_supported(effective_base)
+            _get_base_warning_for_base(effective_base)
 
         super()._pre_run(dispatcher)
 

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -423,7 +423,7 @@ def test_get_base_warning_for_base_emits_message(emitter, base):
     """Test that _get_base_warning_for_base emits the correct message for core22, core24, and core26."""
     application._get_base_warning_for_base(base)
 
-    emitter.assert_message(
+    emitter.assert_warning(
         f"Base {base!r} is supported in Snapcraft 9.x. "
         "It is recommended to upgrade to Snapcraft 9.x via the 'latest/stable' channel "
         "to benefit from the latest bug fixes and performance improvements."

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -418,6 +418,18 @@ def test_esm_pass(mocker, snapcraft_yaml, base):
         mock_dispatch.assert_called_once()
 
 
+@pytest.mark.parametrize("base", ["core22", "core24", "core26"])
+def test_get_base_warning_for_base_emits_message(emitter, base):
+    """Test that _get_base_warning_for_base emits the correct message for core22, core24, and core26."""
+    application._get_base_warning_for_base(base)
+
+    emitter.assert_message(
+        f"Base {base!r} is supported in Snapcraft 9.x. "
+        "It is recommended to upgrade to Snapcraft 9.x via the 'latest/stable' channel "
+        "to benefit from the latest bug fixes and performance improvements."
+    )
+
+
 def test_yaml_syntax_error(in_project_path, monkeypatch, capsys):
     """Provide a user friendly error on yaml syntax errors."""
     (in_project_path / "snapcraft.yaml").write_text("bad:\nyaml")


### PR DESCRIPTION
## Description
Add a warning message recommending Snapcraft 9.x when building 
snaps with core22, core24, or core26 bases.

Closes #4958

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
