### PR TITLE
ci: make workflows conditional, add docs-only spread tests

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,6 +2,10 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "*.md"
   push:
     branches:
       - "feature/**"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,6 +6,7 @@ on:
       - "docs/**"
       - "**/*.md"
       - "*.md"
+      - ".readthedocs.yaml"
   push:
     branches:
       - "feature/**"

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -14,6 +14,8 @@ jobs:
     uses: canonical/starflow/.github/workflows/lint-python.yaml@main
   test:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
+    needs: lint
+    if: ${{ needs.lint.outputs.source-files == 'true' }}
     with:
       # Snapcraft currently only tests on Python 3.12 on Ubuntu 24.04
       fast-test-platforms: '["ubuntu-24.04"]'

--- a/.github/workflows/spread-docs.yaml
+++ b/.github/workflows/spread-docs.yaml
@@ -1,0 +1,74 @@
+name: Spread tests for docs
+on:
+  pull_request:
+    paths:
+      - .github/workflows/spread-docs.yaml
+      - spread.yaml
+      - docs/**/code/**
+  push:
+    branches:
+      - main
+    paths:
+      - spread.yaml
+      - docs/**/code/**
+  schedule:
+    - cron: "0 2 * * 0" # Run every Sunday at 02:00
+
+jobs:
+  docs-snap-build:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      # speed up build times by using wheels, when available
+      - name: Use wheels
+        run: |
+          yq eval 'del(.parts.snapcraft.build-environment[] | select(.UV_NO_BINARY == "true"))' -i snap/snapcraft.yaml
+
+      - name: Build snap
+        uses: canonical/action-build@v1
+        id: snapcraft
+
+      - name: Upload snap artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: snap
+          path: ${{ steps.snapcraft.outputs.snap }}
+
+  docs-spread-tests:
+    runs-on: [self-hosted, spread-installed]
+    needs: [docs-snap-build]
+    timeout-minutes: 90
+
+    steps:
+      - name: Cleanup job workspace
+        run: |
+          rm -rf "${{ github.workspace }}"
+          mkdir "${{ github.workspace }}"
+      - name: Checkout rockcraft
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Download snap artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: snap
+          path: tests
+
+      - name: Run docs spread tests
+        run: |
+          spread google:...docs...
+
+      - name: Discard spread workers
+        if: always()
+        run: |
+          shopt -s nullglob
+          for r in .spread-reuse.*.yaml; do
+            spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')"
+          done

--- a/.github/workflows/spread-docs.yaml
+++ b/.github/workflows/spread-docs.yaml
@@ -4,12 +4,14 @@ on:
     paths:
       - .github/workflows/spread-docs.yaml
       - spread.yaml
+      - .readthedocs.yaml
       - docs/**/code/**
   push:
     branches:
       - main
     paths:
       - spread.yaml
+      - .readthedocs.yaml
       - docs/**/code/**
   schedule:
     - cron: "0 2 * * 0" # Run every Sunday at 02:00

--- a/.github/workflows/spread-docs.yaml
+++ b/.github/workflows/spread-docs.yaml
@@ -51,14 +51,14 @@ jobs:
         run: |
           rm -rf "${{ github.workspace }}"
           mkdir "${{ github.workspace }}"
-      - name: Checkout rockcraft
-        uses: actions/checkout@v5
+      - name: Checkout Snapcraft
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: true
 
       - name: Download snap artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: snap
           path: tests

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -27,7 +27,7 @@ jobs:
           # If we ever need to filter only for docs, glob 'docs/**/*' and '**/*.md'
           filters: |
             source-files:
-              - '!({docs/**,*.md,**/*.md})'
+              - '!({docs/**,*.md,**/*.md,.readthedocs.yaml})'
 
       # speed up build times by using wheels, when available
       - name: Use wheels

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -1,4 +1,4 @@
-name: Spread Tests
+name: Spread tests for source
 
 on:
   pull_request:
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      source-files: ${{ steps.filter.outputs.source-files }}
 
     steps:
       - name: Checkout snapcraft
@@ -17,28 +19,43 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check which files changed
+        id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          # Combine multiple negation checks into a union (¬A ∧ ¬B ∧ ¬C), because individual entries are checked independently (A ∨ B ∨ C).
+          # If we ever need to filter only for docs, glob 'docs/**/*' and '**/*.md'
+          filters: |
+            source-files:
+              - '!({docs/**,*.md,**/*.md})'
+
       # speed up build times by using wheels, when available
       - name: Use wheels
+        if: steps.filter.outputs.source-files == 'true'
         run: |
           yq eval 'del(.parts.snapcraft.build-environment[] | select(.UV_NO_BINARY == "true"))' -i snap/snapcraft.yaml
 
       - name: Build snapcraft snap
         id: build-snapcraft
         uses: canonical/action-build@v1
+        if: steps.filter.outputs.source-files == 'true'
 
       - name: Upload snapcraft snap
         uses: actions/upload-artifact@v7
+        if: steps.filter.outputs.source-files == 'true'
         with:
           name: snap
           path: ${{ steps.build-snapcraft.outputs.snap }}
 
       - name: Verify snapcraft snap
+        if: steps.filter.outputs.source-files == 'true'
         run: |
           sudo snap install --dangerous --classic ${{ steps.build-snapcraft.outputs.snap }}
 
   integration-spread-tests:
     runs-on: [spread-installed]
     needs: build
+    if: ${{ needs.build.outputs.source-files == 'true' }}
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.
       # Disable fail-fast mode as it doesn't function with spread. It seems
@@ -83,6 +100,7 @@ jobs:
   integration-spread-tests-store:
     runs-on: [spread-installed]
     needs: build
+    if: ${{ needs.build.outputs.source-files == 'true' }}
     strategy:
       # FIXME: enable fail-fast mode once spread can cancel an executing job.
       # Disable fail-fast mode as it doesn't function with spread. It seems


### PR DESCRIPTION
Make workflows and jobs conditional:

- `QA / Test` runs if source files change.
- `CI` runs if source files change.
- The `Spread tests for source` (renamed) workflow calls the test/** Spread tests if source files change.

Add a `Spread tests for docs` workflow that runs the doc tests on the Google backend if docs files change.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
