### PR TITLE
feat: deprecation warning for snap_daemon system username

### DIFF
--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -487,7 +487,9 @@ def get_metadata_from_project(
         slots=project.slots,
         hooks=project.hooks,
         layout=project.layout,
-        system_usernames=project.system_usernames,
+        system_usernames=project.system_usernames.model_dump(exclude_none=True)
+        if project.system_usernames is not None
+        else None,
         provenance=project.provenance,
         links=links if links else None,
         components=components,

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -1258,6 +1258,29 @@ class Platform(models.Platform):
         return platforms
 
 
+class SystemUsernames(models.CraftBaseModel, extra="allow"):
+    """System usernames the snap can use to run daemons.
+
+    See :external+snap:ref:`interfaces-system-usernames` in the snap documentation for
+    more information.
+    """
+
+    snap_daemon: Annotated[
+        str | dict[str, Any] | None,
+        pydantic.Field(
+            default=None,
+            deprecated=(
+                "The 'snap_daemon' system username is deprecated. "
+                "See https://snapcraft.io/docs/system-usernames."
+            ),
+        ),
+    ] = None
+    """Deprecated system username.
+
+    Use ``snap_microk8s``, ``snap_aziotedge``, or ``snap_aziotdu`` instead.
+    """
+
+
 class Component(models.CraftBaseModel):
     """Snapcraft component definition."""
 
@@ -1791,15 +1814,12 @@ class Project(models.Project):
       adopting part.
     """
 
-    system_usernames: dict[str, Any] | None = pydantic.Field(
+    system_usernames: SystemUsernames | None = pydantic.Field(
         default=None,
         description="The system usernames the snap can use to run daemons and services.",
         examples=["{snap-daemon: shared}"],
     )
     """The system usernames the snap can use to run daemons and services.
-
-    This is used to run daemons with the ``snap_daemon`` user defined by snapd.
-    Otherwise, this is an uncommon key.
 
     See :external+snap:ref:`interfaces-system-usernames` in the snap documentation for
     more information.
@@ -1953,6 +1973,18 @@ class Project(models.Project):
             emit.message(message)
 
         return slots
+
+    @pydantic.field_validator("system_usernames")
+    @classmethod
+    def _validate_system_usernames(
+        cls, system_usernames: SystemUsernames
+    ) -> SystemUsernames:
+        if system_usernames and system_usernames.snap_daemon is not None:
+            emit.warning(
+                "The 'snap_daemon' system username is deprecated. "
+                "See https://snapcraft.io/docs/system-usernames."
+            )
+        return system_usernames
 
     @pydantic.model_validator(mode="after")
     def _validate_adoptable_fields(self) -> Self:

--- a/tests/unit/models/test_projects.py
+++ b/tests/unit/models/test_projects.py
@@ -1654,7 +1654,38 @@ class TestAppValidation:
     )
     def test_project_system_usernames_valid(self, system_username, project_yaml_data):
         project = Project.unmarshal(project_yaml_data(system_usernames=system_username))
-        assert project.system_usernames == system_username
+        assert project.system_usernames is not None
+        for key, value in system_username.items():
+            assert getattr(project.system_usernames, key, None) == value
+
+    @pytest.mark.parametrize(
+        "system_username",
+        [
+            {"snap_daemon": {"scope": "shared"}},
+            {"snap_daemon": "shared"},
+        ],
+    )
+    def test_project_system_usernames_snap_daemon_deprecated(
+        self, system_username, project_yaml_data, emitter
+    ):
+        Project.unmarshal(project_yaml_data(system_usernames=system_username))
+        emitter.assert_warning(
+            "The 'snap_daemon' system username is deprecated. "
+            "See https://snapcraft.io/docs/system-usernames."
+        )
+
+    @pytest.mark.parametrize(
+        "system_username",
+        [
+            {"snap_microk8s": {"scope": "shared"}},
+            {"snap_aziotedge": "shared"},
+        ],
+    )
+    def test_project_system_usernames_no_warning_for_others(
+        self, system_username, project_yaml_data, emitter
+    ):
+        Project.unmarshal(project_yaml_data(system_usernames=system_username))
+        assert not any(i for i in emitter.interactions if i[0] == "warning")
 
     @pytest.mark.parametrize(
         "system_username",


### PR DESCRIPTION
Add a SystemUsernames pydantic model with snap_daemon marked as deprecated, so the JSON schema exposes 'deprecated: true' on that key. Also emit a runtime warning via craft-cli when snap_daemon is used.

Fixes: https://github.com/canonical/snapcraft/issues/5448

Describe your changes.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
