### PR TITLE
ci: fix release-drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -8,8 +8,10 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Release Drafter
-        uses: release-drafter/release-drafter@v7.2.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: release-drafter/release-drafter@c2e2804cc59f45f57076a99af580d0fedb697927 # v7.3.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -5,11 +5,13 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Release Drafter
         uses: release-drafter/release-drafter@c2e2804cc59f45f57076a99af580d0fedb697927 # v7.3.0


### PR DESCRIPTION
Update the `release-drafter.yaml` workflow to work with version 7 and newer.

Looks like this got bumped without addressing the breaking changes. I just fixed this in our Sphinx extension repos, so I figured I'd propose it here. You can see this run successfully in [the extension template](https://github.com/canonical/sphinx-ext-template/actions/runs/26241986582/job/77230478577).

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
~~I've successfully run `make lint && make test`.~~
~~I've added or updated any relevant documentation.~~
~~In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.~~
~~I've updated the relevant release notes.~~
