### PR TITLE
docs: add parts and steps redirect

### DIFF
--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -58,6 +58,7 @@
 "reference/changelog.rst" "release-notes/changelog.rst"
 "reference/parts_steps.rst" "reference/parts-steps.rst"
 "reference/parts/part-environment-variables.rst" "reference/part-environment-variables.rst"
+"reference/parts/parts-and-steps.rst" "reference/parts-steps.rst"
 "reference/parts/index.rst" "reference/parts-steps.rst"
 "reference/snap-build-process.rst" "reference/processes/snap-build-process.rst"
 "reference/snap-publishing-process.rst" "reference/processes/snap-publishing-process.rst"


### PR DESCRIPTION
Fixes a broken redirect from #6227.

The broken link is the first link on this page: https://snapcraft.io/docs/reference/development/environment-variables/

Found by @dilyn-corner.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
