### PR TITLE
style: fix gnome extension typing

### DIFF
--- a/snapcraft/extensions/gnome.py
+++ b/snapcraft/extensions/gnome.py
@@ -333,16 +333,10 @@ class GNOME(GPUExtension):
         else:
             parts = {}
 
-        parts.update(
-            {
-                "gnome/sdk": {
-                    "source": str(source),
-                    "plugin": "make",
-                },
-            }
-        )
-
-        if self.gnome_snaps.builtin:
-            parts["gnome/sdk"]["build-snaps"] = [_SDK_SNAP[base]]
+        parts["gnome/sdk"] = {
+            "source": str(source),
+            "plugin": "make",
+            **({"build-snaps": [_SDK_SNAP[base]]} if self.gnome_snaps.builtin else {}),
+        }
 
         return parts


### PR DESCRIPTION
Fixes a new error caught by `ty`.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
