### PR TITLE
style: ignore configparser shadowing

### DIFF
--- a/snapcraft/parts/desktop_file.py
+++ b/snapcraft/parts/desktop_file.py
@@ -21,14 +21,13 @@ from __future__ import annotations
 import configparser
 import os
 import shlex
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from craft_cli import emit
 
 from snapcraft import errors
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
     from pathlib import Path
 
 
@@ -58,7 +57,9 @@ class DesktopFile:
             )
 
         self._parser = configparser.ConfigParser(interpolation=None)
-        self._parser.optionxform: Callable[[Any], str] = str
+        # The configparser docs recommend overriding this function to preserve the case.
+        # However, ty doesn't like attribute assignment that shadows a class method.
+        self._parser.optionxform = str  # ty: ignore[invalid-assignment]
         self._parser.read(file_path, encoding="utf-8")
 
     def _parse_and_reformat_section_exec(self, section: str):


### PR DESCRIPTION
Ty no longer likes the typing change from #6247.

The alternative is to subclass and override, but the configparser docs are adamant that you don't need to subclass to do this.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
