### PR TITLE
build: add fallback version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,8 @@ git_describe_command = [
 # Appends "+dirty" to the version when working dir is dirty
 # Necessary to avoid version numbers being too long
 local_scheme = "dirty-tag"
+# Used when the git version can't be determined, like when building from a worktree.
+fallback_version = "0.0.0"
 
 [tool.setuptools.packages.find]
 include = ["snapcraft", "extensions", "keyrings", "schema"]


### PR DESCRIPTION
Adds a fallback version.

I switched to worktree-based development a few months ago and I've been manually adding this line everytime I build snapcraft.


---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
