### PR TITLE
docs: split supported CPU architectures

### DIFF
--- a/docs/reference/architectures.rst
+++ b/docs/reference/architectures.rst
@@ -257,13 +257,45 @@ available in any of the following scenarios:
 
 .. _supported-architectures:
 
-Supported architectures
------------------------
+Supported CPU architectures
+---------------------------
 
-Supported locally
+core22 and higher
 ^^^^^^^^^^^^^^^^^
 
-The following architectures can be used when building a snap locally.
+Local builds
+""""""""""""
+
+Snapcraft supports building for these architectures locally:
+
+* amd64
+* arm64
+* armhf
+* ppc64el
+* riscv64
+* s390x
+
+.. _supported-architectures-launchpad:
+
+Launchpad builds
+""""""""""""""""
+
+Launchpad supports remote building for these architectures:
+
+* amd64
+* arm64
+* armhf
+* ppc64el
+* riscv64
+* s390x
+
+core20
+^^^^^^
+
+Local builds
+""""""""""""
+
+Snapcraft supports building for these architectures locally:
 
 * amd64
 * arm64
@@ -274,16 +306,15 @@ The following architectures can be used when building a snap locally.
 * riscv64
 * s390x
 
-.. _supported-architectures-launchpad:
+Launchpad builds
+""""""""""""""""
 
-Supported by Launchpad
-^^^^^^^^^^^^^^^^^^^^^^
-
-The following architectures are supported by Launchpad for remote building.
+Launchpad supports remote building for these architectures:
 
 * amd64
 * arm64
 * armhf
+* i386
 * ppc64el
 * riscv64
 * s390x


### PR DESCRIPTION
Fixes #5224

* Split the [reference documentation](https://canonical-snapcraft.readthedocs-hosted.com/en/latest/reference/architectures/#supported-architectures) about supported architectures by base.  
  * The difference between bases is that support for `i386` and `powerpc` (not `ppc64el`) was dropped in `core22` and newer bases.
  * "Supported locally" and "supported by launchpad" are the same for core22 and newer bases. For core20, "powerpc" is locally supported.

**Support for core20 and core22 and higher is now correctly split according to the request.**

* Update outdated docs or point them to read the docs:
  * https://snapcraft.io/docs/reference-architectures#supported-architectures
  * https://snapcraft.io/docs/build-from-github

**The links above were broken and what seemed to be the corresponding doc now was already pointing to the supported architectures.**

I spotted this issue that looked like a good first issue, I stay available for any further modifications.
I believe the meta description update is not relevant in this case and I suppose that I should wait for the approval of this PR to update the relevant release notes.
Best regards.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
