### PR TITLE
feat(components): support per-component compression

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -2927,6 +2927,21 @@
           "description": "Selects a part to inherit metadata from and reuse for the component's\nmetadata.\n\nOnly the component's version can be set.\n",
           "examples": ["foo-part"],
           "title": "Adopt-Info"
+        },
+        "compression": {
+          "anyOf": [
+            {
+              "enum": ["lzo", "xz"],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Specifies the algorithm that compresses this component.",
+          "examples": ["xz", "lzo"],
+          "title": "Compression"
         }
       },
       "required": ["summary", "description", "type"],

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -1361,9 +1361,9 @@ class Component(models.CraftBaseModel):
         * - Value
           - Description
         * - ``xz``
-          - Use `XZ <https://en.wikipedia.org/wiki/XZ_Utils>`_ compression.
+          - Use `XZ <https://en.wikipedia.org/wiki/XZ_Utils>`__ compression.
         * - ``lzo``
-          - Use `LZO <https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Oberhumer>`_ compression.
+          - Use `LZO <https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Oberhumer>`__ compression.
 
     """
 
@@ -1432,9 +1432,9 @@ class Project(models.Project):
         * - Value
           - Description
         * - ``xz``
-          - Default. Use `XZ <https://en.wikipedia.org/wiki/XZ_Utils>`_ compression.
+          - Default. Use `XZ <https://en.wikipedia.org/wiki/XZ_Utils>`__ compression.
         * - ``lzo``
-          - Use `LZO <https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Oberhumer>`_ compression.
+          - Use `LZO <https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Oberhumer>`__ compression.
 
     """
 

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -1345,11 +1345,9 @@ class Component(models.CraftBaseModel):
     )
     """Specifies the algorithm that compresses this component.
 
-    If not set, the component inherits the snap's ``compression`` setting.
-
-    Components are compressed using the snap's ``compression`` setting. By default, this
-    is the ``xz`` algorighm. This offers the optimal performance to compression ratio
-    for the majority of components.
+    If not set, the component inherits the snap's ``compression`` setting. By default,
+    this is the ``xz`` algorithm. This offers the optimal performance to compression
+    ratio for the majority of components.
 
     However, certain components, such as large pre-compressed data files, can
     benefit from using LZO compression. Components compressed with LZO are

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -1338,6 +1338,49 @@ class Component(models.CraftBaseModel):
     For example, ``craftctl set components.my-component.version=$(git describe)``.
     """
 
+    compression: Literal["lzo", "xz"] | None = pydantic.Field(
+        default=None,
+        description="Specifies the algorithm that compresses this component.",
+        examples=["xz", "lzo"],
+    )
+    """Specifies the algorithm that compresses this component.
+
+    If not set, the component inherits the snap's ``compression`` setting.
+
+    Components are compressed using the snap's ``compression`` setting. By default, this
+    is the ``xz`` algorighm. This offers the optimal performance to compression ratio
+    for the majority of components.
+
+    However, certain components, such as large pre-compressed data files, can
+    benefit from using LZO compression. Components compressed with LZO are
+    slightly larger but decompress quicker, reducing load time.
+
+    **Values**
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Value
+          - Description
+        * - ``xz``
+          - Use `XZ <https://en.wikipedia.org/wiki/XZ_Utils>`_ compression.
+        * - ``lzo``
+          - Use `LZO <https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Oberhumer>`_ compression.
+
+    """
+
+    @pydantic.model_validator(mode="after")
+    def _validate_compression(self) -> Component:
+        # Compression is optional because it will default to the snap's compression.
+        # However, we don't want users to specify `compression: null` in their
+        # project  file, because that is reserved for uncompressed components.
+        if "compression" in self.model_fields_set and self.compression is None:
+            raise ValueError(
+                "Setting compression to null is not supported. "
+                "Remove the 'compression' key to inherit the snap's compression."
+            )
+        return self
+
 
 MANDATORY_ADOPTABLE_FIELDS = ("version", "summary", "description")
 

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -1373,7 +1373,7 @@ class Component(models.CraftBaseModel):
     def _validate_compression(self) -> Component:
         # Compression is optional because it will default to the snap's compression.
         # However, we don't want users to specify `compression: null` in their
-        # project  file, because that is reserved for uncompressed components.
+        # project file, because that is reserved for uncompressed components.
         if "compression" in self.model_fields_set and self.compression is None:
             raise ValueError(
                 "Setting compression to null is not supported. "

--- a/snapcraft/services/package.py
+++ b/snapcraft/services/package.py
@@ -245,13 +245,24 @@ class Package(PackageService):
 
     def _pack_components(self, dest: pathlib.Path) -> dict[str, pathlib.Path]:
         component_map: dict[str, pathlib.Path] = {}
-        for component in self._project.get_component_names():
+        if not self._project.components:
+            return component_map
+
+        for component_name, component in self._project.components.items():
+            if compression := component.compression:
+                emit.debug(f"Using {compression} compression for {component_name}.")
+            else:
+                compression = self._project.compression
+                emit.debug(
+                    f"Using the snap's {compression} compression for {component_name}."
+                )
+
             filename = pack.pack_component(
-                cast(Lifecycle, self._services.lifecycle).get_prime_dir(component),
-                compression=self._project.compression,
+                cast(Lifecycle, self._services.lifecycle).get_prime_dir(component_name),
+                compression=compression,
                 output_dir=dest,
             )
-            component_map[component] = pathlib.Path(filename)
+            component_map[component_name] = pathlib.Path(filename)
 
         return component_map
 

--- a/snapcraft/services/package.py
+++ b/snapcraft/services/package.py
@@ -245,10 +245,7 @@ class Package(PackageService):
 
     def _pack_components(self, dest: pathlib.Path) -> dict[str, pathlib.Path]:
         component_map: dict[str, pathlib.Path] = {}
-        if not self._project.components:
-            return component_map
-
-        for component_name, component in self._project.components.items():
+        for component_name, component in (self._project.components or {}).items():
             if compression := component.compression:
                 emit.debug(f"Using {compression!r} compression for {component_name!r}.")
             else:

--- a/snapcraft/services/package.py
+++ b/snapcraft/services/package.py
@@ -245,21 +245,27 @@ class Package(PackageService):
 
     def _pack_components(self, dest: pathlib.Path) -> dict[str, pathlib.Path]:
         component_map: dict[str, pathlib.Path] = {}
-        for component_name, component in (self._project.components or {}).items():
-            if compression := component.compression:
-                emit.debug(f"Using {compression!r} compression for {component_name!r}.")
-            else:
-                compression = self._project.compression
-                emit.debug(
-                    f"Using the snap's {compression!r} compression for {component_name!r}."
-                )
 
-            filename = pack.pack_component(
-                cast(Lifecycle, self._services.lifecycle).get_prime_dir(component_name),
-                compression=compression,
-                output_dir=dest,
-            )
-            component_map[component_name] = pathlib.Path(filename)
+        if self._project.components is not None:
+            for component_name, component in self._project.components.items():
+                if compression := component.compression:
+                    emit.debug(
+                        f"Using {compression!r} compression for {component_name!r}."
+                    )
+                else:
+                    compression = self._project.compression
+                    emit.debug(
+                        f"Using the snap's {compression!r} compression for {component_name!r}."
+                    )
+
+                filename = pack.pack_component(
+                    cast(Lifecycle, self._services.lifecycle).get_prime_dir(
+                        component_name
+                    ),
+                    compression=compression,
+                    output_dir=dest,
+                )
+                component_map[component_name] = pathlib.Path(filename)
 
         return component_map
 

--- a/snapcraft/services/package.py
+++ b/snapcraft/services/package.py
@@ -250,11 +250,11 @@ class Package(PackageService):
 
         for component_name, component in self._project.components.items():
             if compression := component.compression:
-                emit.debug(f"Using {compression} compression for {component_name}.")
+                emit.debug(f"Using {compression!r} compression for {component_name!r}.")
             else:
                 compression = self._project.compression
                 emit.debug(
-                    f"Using the snap's {compression} compression for {component_name}."
+                    f"Using the snap's {compression!r} compression for {component_name!r}."
                 )
 
             filename = pack.pack_component(

--- a/spread.yaml
+++ b/spread.yaml
@@ -146,6 +146,7 @@ prepare: |
 
   tests.pkgs remove lxd
   snap install lxd --channel=5.21/stable
+  snap install yq
 
   # Hold snap refreshes for 24h.
   snap set system refresh.hold="$(date --date=tomorrow +%Y-%m-%dT%H:%M:%S%:z)"

--- a/tests/spread/_common/components-compression/snapcraft.yaml
+++ b/tests/spread/_common/components-compression/snapcraft.yaml
@@ -1,0 +1,28 @@
+name: hello-compression
+version: "1.0"
+summary: Test per-component compression
+description: Test per-component compression
+base: core24
+confinement: strict
+compression: xz
+
+apps:
+  hello-app:
+    command: hello-app
+  hello-comp:
+    command: load-comp
+
+components:
+  test-comp:
+    version: "1.0"
+    type: standard
+    summary: A test component
+    description: A test component for compression testing
+    compression: xz
+
+parts:
+  hello:
+    plugin: dump
+    source: src
+    organize:
+      hello-comp: (component/test-comp)/hello-comp

--- a/tests/spread/_common/components-compression/src/hello-app
+++ b/tests/spread/_common/components-compression/src/hello-app
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "hello app"

--- a/tests/spread/_common/components-compression/src/hello-comp
+++ b/tests/spread/_common/components-compression/src/hello-comp
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "hello component"

--- a/tests/spread/_common/components-compression/src/load-comp
+++ b/tests/spread/_common/components-compression/src/load-comp
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+COMP_BIN="$SNAP/../components/$SNAP_REVISION/test-comp/hello-comp"
+
+if [ ! -f "$COMP_BIN" ]; then
+    echo "Error: 'test-comp' component is not installed" >&2
+    exit 1
+fi
+
+"$COMP_BIN"

--- a/tests/spread/_common/components-compression/task.yaml
+++ b/tests/spread/_common/components-compression/task.yaml
@@ -1,0 +1,54 @@
+summary: Test per-component compression algorithms
+
+environment:
+  SNAP_COMPRESSION: xz
+  # snap and component use the same compression
+  COMPONENT_COMPRESSION/xz: xz
+  # snap and component use different compressions
+  COMPONENT_COMPRESSION/lzo: lzo
+  COMPONENT_COMPRESSION/null_failure: "null"
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "snapcraft.yaml"
+
+  # the yq snap can't access most directories (https://github.com/mikefarah/yq#snap-notes)
+  cat snapcraft.yaml | yq '.compression = env(SNAP_COMPRESSION) | .components["test-comp"].compression = env(COMPONENT_COMPRESSION)' > snapcraft.yaml.tmp
+  mv snapcraft.yaml.tmp snapcraft.yaml
+
+execute: |
+  if [[ "$SPREAD_VARIANT" == "null_failure" ]]; then
+    snapcraft pack 2>&1 | MATCH "Setting compression to null is not supported"
+    exit 0
+  fi
+
+  snapcraft pack
+
+  snap_file="hello-compression_1.0_amd64.snap"
+  comp_file="hello-compression+test-comp_1.0.comp"
+
+  # assert snap compression
+  unsquashfs -s "${snap_file}" | grep Compression | MATCH "${SNAP_COMPRESSION}"
+
+  # assert component compression
+  unsquashfs -s "${comp_file}" | grep Compression | MATCH "${COMPONENT_COMPRESSION}"
+
+  # install snap, then component
+  snap install --dangerous "${snap_file}"
+  snap install --dangerous "${comp_file}"
+
+  # verify snap app prints snap output and component output
+  hello-compression.hello-app | MATCH "hello app"
+  hello-compression.hello-comp | MATCH "hello component"
+
+restore: |
+  snap remove hello-compression --purge
+  if [[ "$SPREAD_VARIANT" != "null_failure" ]]; then
+    snapcraft clean
+  fi
+  rm -f ./*.snap ./*.comp
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snapcraft.yaml"

--- a/tests/spread/_common/manifest-creation/task.yaml
+++ b/tests/spread/_common/manifest-creation/task.yaml
@@ -2,7 +2,6 @@ summary: Test manifest file creation
 
 prepare: |
   snap install review-tools
-  snap install yq
 
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"

--- a/tests/spread/_common/metadata-links/task.yaml
+++ b/tests/spread/_common/metadata-links/task.yaml
@@ -4,8 +4,6 @@ environment:
   SNAP_YAML: prime/meta/snap.yaml
 
 prepare: |
-  snap install yq
-
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   set_base "snapcraft.yaml"

--- a/tests/spread/_common/project-variables/task.yaml
+++ b/tests/spread/_common/project-variables/task.yaml
@@ -4,8 +4,6 @@ environment:
   SNAPCRAFT_PARALLEL_BUILD_COUNT: 1
 
 prepare: |
-  snap install yq
-
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   set_base "snapcraft.yaml"
@@ -23,7 +21,6 @@ execute: |
   fi
 
 restore: |
-  snap remove --purge yq
   rm -f ./*.snap
   snapcraft clean
 

--- a/tests/spread/core22/project-variables/task.yaml
+++ b/tests/spread/core22/project-variables/task.yaml
@@ -3,11 +3,7 @@ summary: Test project variables on core24
 environment:
   SNAPCRAFT_PARALLEL_BUILD_COUNT: 1
 
-prepare: |
-  snap install yq
-
 restore: |
-  snap remove --purge yq
   rm -f ./*.snap
   snapcraft clean
 

--- a/tests/spread/core24-suites/manifest/manifest-creation/task.yaml
+++ b/tests/spread/core24-suites/manifest/manifest-creation/task.yaml
@@ -8,7 +8,6 @@ environment:
 
 prepare: |
   snap install review-tools
-  snap install yq
 
 restore: |
   snapcraft clean --destructive-mode

--- a/tests/spread/core24/components-compression
+++ b/tests/spread/core24/components-compression
@@ -1,0 +1,1 @@
+../_common/components-compression

--- a/tests/spread/core24/metadata-links/task.yaml
+++ b/tests/spread/core24/metadata-links/task.yaml
@@ -3,9 +3,6 @@ summary: Metadata links transformation from snapcraft.yaml to snap.yaml
 environment:
   SNAP_YAML: prime/meta/snap.yaml
 
-prepare: |
-  snap install yq
-
 restore: |
   snapcraft clean --destructive-mode
 

--- a/tests/spread/core24/project-variables/task.yaml
+++ b/tests/spread/core24/project-variables/task.yaml
@@ -3,11 +3,7 @@ summary: Test project variables on core24
 environment:
   SNAPCRAFT_PARALLEL_BUILD_COUNT: 1
 
-prepare: |
-  snap install yq
-
 restore: |
-  snap remove --purge yq
   rm -f ./*.snap
   snapcraft clean
 

--- a/tests/spread/core26/components-compression
+++ b/tests/spread/core26/components-compression
@@ -1,0 +1,1 @@
+../_common/components-compression

--- a/tests/spread/general/metadata-links/task.yaml
+++ b/tests/spread/general/metadata-links/task.yaml
@@ -4,8 +4,6 @@ environment:
   SNAP_YAML: prime/meta/snap.yaml
 
 prepare: |
-  snap install yq
-
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   set_base snapcraft.yaml

--- a/tests/spread/store/confdbs/task.yaml
+++ b/tests/spread/store/confdbs/task.yaml
@@ -20,7 +20,6 @@ prepare: |
   # import a registered key
   gpg --homedir "$HOME/.snap/gnupg" --import <(echo "$SNAPCRAFT_ASSERTION_KEY" | base64 --decode)
 
-  snap install yq
   # confdb schemas only available in edge
   snap refresh snapd --edge
 
@@ -38,5 +37,4 @@ execute: |
 restore: |
   rm -rf "$HOME/.snap/gnupg"
 
-  snap remove --purge yq
   snap refresh snapd --stable

--- a/tests/spread/store/validation-sets/task.yaml
+++ b/tests/spread/store/validation-sets/task.yaml
@@ -20,8 +20,6 @@ prepare: |
   # import a registered key
   gpg --homedir "$HOME/.snap/gnupg" --import <(echo "$SNAPCRAFT_ASSERTION_KEY" | base64 --decode)
 
-  snap install yq
-
 execute: |
   # ensure snapcraft is logged in and can access the store
   snapcraft whoami
@@ -35,5 +33,3 @@ execute: |
 
 restore: |
   rm -rf "$HOME/.snap/gnupg"
-
-  snap remove --purge yq

--- a/tests/spread/tools/restore.sh
+++ b/tests/spread/tools/restore.sh
@@ -15,7 +15,7 @@ apt-get autoremove --purge -y
 snaps="$(snap list | awk '{if (NR!=1) {print $1}}')"
 for snap in $snaps; do
 	case "$snap" in
-		"bare" | "core" | "core18" | "core20" | "core22" | "core24" | "core26" | "snapcraft" | "multipass" | "lxd" | "snapd")
+		"bare" | "core" | "core18" | "core20" | "core22" | "core24" | "core26" | "snapcraft" | "multipass" | "lxd" | "snapd" | "yq")
 			# Do not or cannot remove these
 			;;
 		*)

--- a/tests/unit/models/test_projects.py
+++ b/tests/unit/models/test_projects.py
@@ -2775,6 +2775,43 @@ class TestComponents:
 
         assert partitions is None
 
+    def test_component_compression_default(
+        self, project, project_yaml_data, stub_component_data
+    ):
+        component = {"foo": stub_component_data}
+
+        test_project = project.unmarshal(project_yaml_data(components=component))
+
+        assert test_project.components
+        assert test_project.components["foo"].compression is None
+        # compression is `None` but it's not set to `null` in the project file
+        assert "compression" not in test_project.components["foo"].model_fields_set
+
+    @pytest.mark.parametrize("compression", ["xz", "lzo"])
+    def test_component_compression_valid(
+        self, project, compression, project_yaml_data, stub_component_data
+    ):
+        component = {"foo": stub_component_data}
+        component["foo"]["compression"] = compression
+
+        test_project = project.unmarshal(project_yaml_data(components=component))
+
+        assert test_project.components
+        assert test_project.components["foo"].compression == compression
+
+    def test_component_compression_null_invalid(
+        self, project, project_yaml_data, stub_component_data
+    ):
+        """Error if the compression is set to null."""
+        component = {"foo": stub_component_data}
+        component["foo"]["compression"] = None
+
+        with pytest.raises(
+            pydantic.ValidationError,
+            match="Setting compression to null is not supported",
+        ):
+            project.unmarshal(project_yaml_data(components=component))
+
 
 class TestLint:
     """Test the Lint model."""

--- a/tests/unit/services/test_package_components.py
+++ b/tests/unit/services/test_package_components.py
@@ -109,6 +109,55 @@ def test_pack(default_project, fake_services, setup_project, mocker):
 
 
 @pytest.mark.usefixtures("enable_partitions_feature")
+def test_pack_component_compression(
+    default_project, fake_services, setup_project, mocker
+):
+    """Component-level compression overrides the snap-level compression."""
+    project_data = default_project.marshal()
+    project_data["compression"] = "xz"
+    # 'firstcomponent' defines a compression, 'secondcomponent' defaults to the snaps compression
+    project_data["components"]["firstcomponent"]["compression"] = "lzo"
+    setup_project(fake_services, project_data)
+    package_service = fake_services.get("package")
+    lifecycle_service = fake_services.get("lifecycle")
+    mock_pack_snap = mocker.patch.object(pack, "pack_snap")
+    mock_pack_component = mocker.patch.object(pack, "pack_component")
+
+    mocker.patch.object(linters, "run_linters")
+    mocker.patch.object(linters, "report")
+
+    package_service.pack(prime_dir=Path("prime"), dest=Path())
+
+    mock_pack_snap.assert_called_once_with(
+        Path("prime"),
+        name="default",
+        version="1.0",
+        compression="xz",
+        output=".",
+        target="amd64",
+    )
+
+    mock_pack_component.assert_has_calls(
+        [
+            call(
+                lifecycle_service._work_dir
+                / "partitions/component/firstcomponent/prime",
+                compression="lzo",
+                output_dir=Path("."),
+            ),
+            call().__fspath__(),
+            call(
+                lifecycle_service._work_dir
+                / "partitions/component/secondcomponent/prime",
+                compression="xz",
+                output_dir=Path("."),
+            ),
+            call().__fspath__(),
+        ]
+    )
+
+
+@pytest.mark.usefixtures("enable_partitions_feature")
 def test_write_metadata(
     default_project,
     fake_services,


### PR DESCRIPTION
Allows setting compression per-component.  If not set, the component inherits the snap's compression.

However, you can't set it to null:
```yaml
components:
  my-component:
    compression: null
```

I disallowed this, since we may support uncompressed components in the future.

Also adds a bonus commit that installs `yq` once. There's no good reason to install/uninstall it on every test that uses it.

Fixes #6115
(SNAPCRAFT-1346)

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
