### PR TITLE
docs: fix syntax for H1 heading

### DIFF
--- a/docs/reference/plugins/initrd_plugin.rst
+++ b/docs/reference/plugins/initrd_plugin.rst
@@ -4,7 +4,7 @@
 .. _reference-initrd-plugin:
 
 Initrd plugin
-==============
+=============
 
 The Initrd plugin builds initial ramdisks, or initrds, for kernel snaps. Its
 intended use is to generate the initrds for Ubuntu Core systems.


### PR DESCRIPTION
Fixing a documentation typo which wasn't caught by a lint; no real change.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [x] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [x] I've updated the relevant release notes.
