### PR TITLE
feat: enable pro support

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -82,6 +82,22 @@ jobs:
           name: snap
           path: tests
 
+      - name: Run Ubuntu Pro spread tests
+        env:
+          SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
+          UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
+        run: |
+          if [ -z "$UBUNTU_PRO_TOKEN" ]; then
+            if [ "${{ github.event.pull_request.head.repo.full_name }}" == "canonical/snapcraft" ]; then
+              echo "Error: UBUNTU_PRO_TOKEN is not set."
+              exit 1
+            else
+              echo "Warning: UBUNTU_PRO_TOKEN is not set. Skipping Pro tests"
+              exit 0
+            fi
+          fi
+          spread ${{ matrix.spread-jobs }}:tests/spread/pro/
+
       - name: Run spread
         env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -83,6 +83,7 @@ jobs:
           path: tests
 
       - name: Run Ubuntu Pro spread tests
+        if: matrix.spread-jobs != 'google:ubuntu-22.04-64'
         env:
           SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
           UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}

--- a/snapcraft/application.py
+++ b/snapcraft/application.py
@@ -49,6 +49,7 @@ APP_METADATA = AppMetadata(
     source_ignore_patterns=["*.snap"],
     mandatory_adoptable_fields=list(models.MANDATORY_ADOPTABLE_FIELDS),
     docs_url="https://documentation.ubuntu.com/snapcraft/{version}",
+    enable_pro_support=True,
 )
 
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -330,6 +330,23 @@ suites:
       STORE_UPLOAD_URL: https://storage.staging.snapcraftcontent.com
       UBUNTU_ONE_SSO_URL: https://login.staging.ubuntu.com
 
+  tests/spread/pro/:
+    summary: tests of Ubuntu pro integratiom
+    manual: true
+    systems:
+      - ubuntu-24.04*
+      - ubuntu-26.04*
+    environment:
+      SNAPCRAFT_BUILD_ENVIRONMENT: ""
+      UBUNTU_PRO_TOKEN: '$(HOST: echo "$UBUNTU_PRO_TOKEN")'
+    prepare: |
+      sudo pro attach --no-auto-enable $UBUNTU_PRO_TOKEN
+      sudo pro enable --assume-yes esm-apps
+      sudo pro config set lxd_guest_attach=available
+      sudo snap restart lxd
+    restore: |
+      sudo pro detach --assume-yes
+
   docs/how-to/code/:
     summary: tests how-to guides from the docs
     systems:

--- a/tests/spread/pro/pack/snap/snapcraft.yaml
+++ b/tests/spread/pro/pack/snap/snapcraft.yaml
@@ -1,0 +1,12 @@
+name: pro
+version: '0.1'
+summary: Test snapcraft pack --pro
+description: Verify packing with --pro
+base: core24
+confinement: strict
+
+parts:
+  hello:
+    plugin: nil
+    stage-packages:
+      - hello

--- a/tests/spread/pro/pack/task.yaml
+++ b/tests/spread/pro/pack/task.yaml
@@ -8,7 +8,7 @@ prepare: |
 
 restore: |
   snapcraft clean || true
-  rm -f ./*.snap
+  rm -rf ./snap-contents ./*.snap
 
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
@@ -17,3 +17,6 @@ restore: |
 execute: |
   snapcraft pack --pro=esm-apps
   test -f ./*.snap
+
+  unsquashfs -dest snap-contents ./pro_*.snap
+  grep -q "hello.*~esm" snap-contents/snap/manifest.yaml

--- a/tests/spread/pro/pack/task.yaml
+++ b/tests/spread/pro/pack/task.yaml
@@ -1,0 +1,19 @@
+summary: |
+  Pack snap with pro features enabled.
+
+prepare: |
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  set_base "./snap/snapcraft.yaml"
+
+restore: |
+  snapcraft clean || true
+  rm -f ./*.snap
+
+  #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
+  . "$TOOLS_DIR/snapcraft-yaml.sh"
+  restore_yaml "snap/snapcraft.yaml"
+
+execute: |
+  snapcraft pack --pro=esm-apps
+  test -f ./*.snap

--- a/tests/spread/pro/pack/task.yaml
+++ b/tests/spread/pro/pack/task.yaml
@@ -6,6 +6,13 @@ prepare: |
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   set_base "./snap/snapcraft.yaml"
 
+execute: |
+  snapcraft pack --pro=esm-apps
+  test -f ./*.snap
+
+  unsquashfs -dest snap-contents ./pro_*.snap
+  grep -q "hello.*~esm" snap-contents/snap/manifest.yaml
+
 restore: |
   snapcraft clean || true
   rm -rf ./snap-contents ./*.snap
@@ -13,10 +20,3 @@ restore: |
   #shellcheck source=tests/spread/tools/snapcraft-yaml.sh
   . "$TOOLS_DIR/snapcraft-yaml.sh"
   restore_yaml "snap/snapcraft.yaml"
-
-execute: |
-  snapcraft pack --pro=esm-apps
-  test -f ./*.snap
-
-  unsquashfs -dest snap-contents ./pro_*.snap
-  grep -q "hello.*~esm" snap-contents/snap/manifest.yaml


### PR DESCRIPTION
Enables Pro support and adds a spread test for packing a pro snap

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
