### PR TITLE
chore(store)!: remove candid login

### DIFF
--- a/snapcraft/commands/account.py
+++ b/snapcraft/commands/account.py
@@ -63,9 +63,6 @@ class StoreLoginCommand(AppCommand):
         Log in to the Snap Store with your Ubuntu One SSO credentials.
         If you do not have any, you can create them at https://login.ubuntu.com
 
-        To use the alternative authentication mechanism (Candid), set the
-        environment variable {store.constants.ENVIRONMENT_STORE_AUTH!r} to 'candid'.
-
         The login command requires a working keyring on the system it is used on.
         As an alternative, export {store.constants.ENVIRONMENT_STORE_CREDENTIALS!r}
         with the exported credentials. The login command cannot be used while this
@@ -96,7 +93,13 @@ class StoreLoginCommand(AppCommand):
         if parsed_args.experimental_login:
             raise ArgumentParsingError(
                 "'--experimental-login' is no longer supported. "
-                f"Set {store.constants.ENVIRONMENT_STORE_AUTH}=candid instead.",
+                "Remove '--experimental-login' to login with Ubuntu One."
+            )
+
+        if os.getenv(store.constants.ENVIRONMENT_STORE_AUTH) == "candid":
+            raise ArgumentParsingError(
+                f"{store.constants.ENVIRONMENT_STORE_AUTH}=candid is no longer supported. "
+                f"Unset {store.constants.ENVIRONMENT_STORE_AUTH} to login with Ubuntu One."
             )
 
         if parsed_args.login_with:
@@ -116,12 +119,9 @@ class StoreExportLoginCommand(AppCommand):
     name = "export-login"
     help_msg = "Log in to the Snap Store exporting the credentials"
     overview = textwrap.dedent(
-        f"""
+        """
         Log in to the Snap Store with your Ubuntu One SSO credentials.
         If you do not have any, you can create them at https://login.ubuntu.com
-
-        To use the alternative authentication mechanism (Candid), set the
-        environment variable {store.constants.ENVIRONMENT_STORE_AUTH!r} to 'candid'.
 
         This command exports credentials to use on systems where login is not
         possible or desired. The '--acls' option limits the scope of operations
@@ -183,7 +183,13 @@ class StoreExportLoginCommand(AppCommand):
         if parsed_args.experimental_login:
             raise ArgumentParsingError(
                 "'--experimental-login' is no longer supported. "
-                f"Set {store.constants.ENVIRONMENT_STORE_AUTH}=candid instead.",
+                "Remove '--experimental-login' to login with Ubuntu One."
+            )
+
+        if os.getenv(store.constants.ENVIRONMENT_STORE_AUTH) == "candid":
+            raise ArgumentParsingError(
+                f"{store.constants.ENVIRONMENT_STORE_AUTH}=candid is no longer supported. "
+                f"Unset {store.constants.ENVIRONMENT_STORE_AUTH} to login with Ubuntu One."
             )
 
         kwargs: dict[str, Any] = {}
@@ -227,11 +233,6 @@ class StoreExportLoginCommand(AppCommand):
             message = f"Exported login credentials to {parsed_args.login_file!r}"
 
         message += "\n\nThese credentials must be used on Snapcraft 7.2 or greater."
-        if os.getenv(store.constants.ENVIRONMENT_STORE_AUTH) == "candid":
-            message += (
-                f"\nSet '{store.constants.ENVIRONMENT_STORE_AUTH}=candid' for "
-                "these credentials to work."
-            )
         emit.message(message)
 
 

--- a/snapcraft/store/client.py
+++ b/snapcraft/store/client.py
@@ -59,11 +59,6 @@ def build_user_agent(version: str = __version__):
     return f"snapcraft/{version} {dist_id}/{dist_version} ({dist_arch})"
 
 
-def use_candid() -> bool:
-    """Return True if using candid as the auth backend."""
-    return os.getenv(constants.ENVIRONMENT_STORE_AUTH) == "candid"
-
-
 def is_onprem() -> bool:
     """Return True if using onprem as the auth backend."""
     return os.getenv(constants.ENVIRONMENT_STORE_AUTH) == "onprem"
@@ -144,16 +139,6 @@ def get_client(ephemeral: bool) -> craft_store.BaseClient:
             environment_auth=constants.ENVIRONMENT_STORE_CREDENTIALS,
             ephemeral=ephemeral,
         )
-    elif use_candid() is True:
-        client = craft_store.StoreClient(
-            base_url=store_url,
-            storage_base_url=store_upload_url,
-            application_name="snapcraft",
-            user_agent=user_agent,
-            endpoints=craft_store.endpoints.SNAP_STORE,
-            environment_auth=constants.ENVIRONMENT_STORE_CREDENTIALS,
-            ephemeral=ephemeral,
-        )
     else:
         client = craft_store.UbuntuOneStoreClient(
             base_url=store_url,
@@ -192,7 +177,7 @@ class LegacyStoreClientCLI:
                 resolution=f"Continue without running 'login', or unset {constants.ENVIRONMENT_STORE_CREDENTIALS!r} and try again.",
             )
 
-        if not is_onprem() and use_candid() is False:
+        if not is_onprem():
             kwargs["email"], kwargs["password"] = _prompt_login()
 
         if packages is None:

--- a/snapcraft/store/constants.py
+++ b/snapcraft/store/constants.py
@@ -22,10 +22,9 @@ ENVIRONMENT_STORE_CREDENTIALS: Final[str] = "SNAPCRAFT_STORE_CREDENTIALS"
 """Environment variable where credentials can be picked up from."""
 
 ENVIRONMENT_STORE_AUTH: Final[str] = "SNAPCRAFT_STORE_AUTH"
-"""Environment variable used to set an alternative login method.
+"""Environment variable used to set an alternative login method instead of Ubuntu One.
 
-The only setting that changes the behavior is `candid`, every
-other value uses Ubuntu SSO.
+The only supported choice is `onprem`.
 """
 
 ENVIRONMENT_ADMIN_MACAROON: Final[str] = "SNAPCRAFT_ADMIN_MACAROON"

--- a/snapcraft/store/onprem_client.py
+++ b/snapcraft/store/onprem_client.py
@@ -38,7 +38,12 @@ ON_PREM_ENDPOINTS: Final = endpoints.Endpoints(
 
 
 class OnPremClient(BaseClient):
-    """On Premises Snapcraft Store Client."""
+    """On Premises Snapcraft Store Client.
+
+    This client uses the Candid credentials model, but doesn't actually use Candid
+    auth code. It's more like a macaroon exchange auth that happens to use the Candid
+    credentials model.
+    """
 
     @override
     def _get_macaroon(self, token_request: dict[str, Any]) -> str:

--- a/tests/spread/store/basic-workflow/task.yaml
+++ b/tests/spread/store/basic-workflow/task.yaml
@@ -6,7 +6,6 @@ environment:
   SNAP: "/snapcraft/tests/spread/core22/components-environment/"
   SNAPCRAFT_STORE_CREDENTIALS/ubuntu_one: "$(HOST: echo ${SNAPCRAFT_STORE_CREDENTIALS_STAGING})"
   SNAPCRAFT_STORE_CREDENTIALS/legacy: "$(HOST: echo ${SNAPCRAFT_STORE_CREDENTIALS_STAGING_LEGACY})"
-  SNAPCRAFT_STORE_CREDENTIALS/candid: "$(HOST: echo ${SNAPCRAFT_STORE_CREDENTIALS_STAGING_CANDID})"
 
 prepare: |
   if [[ -z "$SNAPCRAFT_STORE_CREDENTIALS" ]]; then

--- a/tests/unit/commands/test_account.py
+++ b/tests/unit/commands/test_account.py
@@ -78,11 +78,24 @@ def test_login_with_file_error(emitter, mocker, legacy_config_path, fake_app_con
 def test_login_with_experimental_fails(fake_app_config):
     cmd = commands.StoreLoginCommand(fake_app_config)
     expected = re.escape(
-        "'--experimental-login' is no longer supported. Set SNAPCRAFT_STORE_AUTH=candid instead."
+        "'--experimental-login' is no longer supported. "
+        "Remove '--experimental-login' to login with Ubuntu One."
     )
 
     with pytest.raises(craft_cli.errors.ArgumentParsingError, match=expected):
         cmd.run(argparse.Namespace(login_with=None, experimental_login=True))
+
+
+def test_login_with_candid_fails(fake_app_config, monkeypatch):
+    monkeypatch.setenv(store.constants.ENVIRONMENT_STORE_AUTH, "candid")
+    cmd = commands.StoreLoginCommand(fake_app_config)
+    expected = re.escape(
+        f"{store.constants.ENVIRONMENT_STORE_AUTH}=candid is no longer supported. "
+        f"Unset {store.constants.ENVIRONMENT_STORE_AUTH} to login with Ubuntu One."
+    )
+
+    with pytest.raises(craft_cli.errors.ArgumentParsingError, match=expected):
+        cmd.run(argparse.Namespace(login_with=None, experimental_login=False))
 
 
 ########################
@@ -172,44 +185,11 @@ def test_export_login_with_params(emitter, fake_store_login, fake_app_config):
     )
 
 
-def test_export_login_with_candid(
-    emitter, fake_store_login, monkeypatch, fake_app_config
-):
-    monkeypatch.setenv("SNAPCRAFT_STORE_AUTH", "candid")
-
-    cmd = commands.StoreExportLoginCommand(fake_app_config)
-
-    cmd.run(
-        argparse.Namespace(
-            login_file="-",
-            snaps="fake-snap,fake-other-snap",
-            channels="stable,edge",
-            acls="package_manage,package_push",
-            expires="2030-12-12",
-            experimental_login=False,
-        )
-    )
-
-    assert fake_store_login.mock_calls == [
-        call(
-            ANY,
-            packages=["fake-snap", "fake-other-snap"],
-            channels=["stable", "edge"],
-            acls=["package_manage", "package_push"],
-            ttl=ANY,
-        )
-    ]
-    emitter.assert_message(
-        "Exported login credentials:\nsecret"
-        "\n\nThese credentials must be used on Snapcraft 7.2 or greater."
-        "\nSet 'SNAPCRAFT_STORE_AUTH=candid' for these credentials to work."
-    )
-
-
 def test_export_login_with_experimental_fails(fake_app_config):
     cmd = commands.StoreExportLoginCommand(fake_app_config)
     expected = re.escape(
-        "'--experimental-login' is no longer supported. Set SNAPCRAFT_STORE_AUTH=candid instead."
+        "'--experimental-login' is no longer supported. "
+        "Remove '--experimental-login' to login with Ubuntu One."
     )
 
     with pytest.raises(craft_cli.errors.ArgumentParsingError, match=expected):
@@ -221,6 +201,27 @@ def test_export_login_with_experimental_fails(fake_app_config):
                 acls=None,
                 expires=None,
                 experimental_login=True,
+            )
+        )
+
+
+def test_export_login_with_candid_fails(fake_app_config, monkeypatch):
+    monkeypatch.setenv(store.constants.ENVIRONMENT_STORE_AUTH, "candid")
+    cmd = commands.StoreExportLoginCommand(fake_app_config)
+    expected = re.escape(
+        f"{store.constants.ENVIRONMENT_STORE_AUTH}=candid is no longer supported. "
+        f"Unset {store.constants.ENVIRONMENT_STORE_AUTH} to login with Ubuntu One."
+    )
+
+    with pytest.raises(craft_cli.errors.ArgumentParsingError, match=expected):
+        cmd.run(
+            argparse.Namespace(
+                login_file="-",
+                snaps=None,
+                channels=None,
+                acls=None,
+                expires=None,
+                experimental_login=False,
             )
         )
 

--- a/tests/unit/store/test_client.py
+++ b/tests/unit/store/test_client.py
@@ -404,13 +404,6 @@ def test_useragent_linux(mocker):
 #####################
 
 
-@pytest.mark.parametrize("env, expected", (("candid", True), ("not-candid", False)))
-def test_use_candid(monkeypatch, env, expected):
-    monkeypatch.setenv("SNAPCRAFT_STORE_AUTH", env)
-
-    assert client.use_candid() is expected
-
-
 def test_get_store_url():
     assert client.get_store_url() == "https://dashboard.snapcraft.io"
 
@@ -457,16 +450,6 @@ def test_get_hostname():
 #######################
 # StoreClient factory #
 #######################
-
-
-@pytest.mark.parametrize("ephemeral", (True, False))
-def test_get_store_client(monkeypatch, ephemeral, legacy_config_path):
-    monkeypatch.setenv("SNAPCRAFT_STORE_AUTH", "candid")
-    legacy_config_path.unlink()
-
-    store_client = client.get_client(ephemeral)
-
-    assert isinstance(store_client, craft_store.StoreClient)
 
 
 @pytest.mark.parametrize("ephemeral", (True, False))


### PR DESCRIPTION
Removes the candid login method from Snapcraft.

(SNAPCRAFT-1254)

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
