### PR TITLE
docs: remove core18 references outside of release information

### DIFF
--- a/docs/how-to/code/integrations/example-gtk2-recipe.yaml
+++ b/docs/how-to/code/integrations/example-gtk2-recipe.yaml
@@ -15,7 +15,7 @@ license: GPL-2.0
 icon: snap/gui/arduino.png
 grade: stable
 
-base: core18
+base: core22
 confinement: strict
 
 architectures:

--- a/docs/how-to/code/integrations/example-moos-recipe.yaml
+++ b/docs/how-to/code/integrations/example-moos-recipe.yaml
@@ -7,7 +7,7 @@ description: |
   This example includes MOOSDB, the main communication mechanism for all MOOS
   apps.
 
-base: core18
+base: core22
 confinement: devmode
 
 parts:

--- a/docs/how-to/code/integrations/example-pre-built-app.yaml
+++ b/docs/how-to/code/integrations/example-pre-built-app.yaml
@@ -10,7 +10,7 @@ description: |
   How will it perform when push comes to crunch?
   These are the questions that Geekbench can answer.
 confinement: devmode
-base: core18
+base: core22
 
 parts:
   test-geekbench4:

--- a/docs/how-to/code/integrations/example-qt5-kde-recipe.yaml
+++ b/docs/how-to/code/integrations/example-qt5-kde-recipe.yaml
@@ -6,7 +6,7 @@ grade: stable
 adopt-info: kcalc
 
 confinement: strict
-base: core18
+base: core22
 
 apps:
   kcalc:
@@ -34,8 +34,8 @@ parts:
     parse-info:
       - usr/share/metainfo/org.kde.kcalc.appdata.xml
     build-snaps:
-      - kde-frameworks-5-core18-sdk
-      - kde-frameworks-5-core18
+      - kde-frameworks-5-core22-sdk
+      - kde-frameworks-5-core22
     build-packages:
       - libmpfr-dev
       - libgmp-dev

--- a/docs/how-to/code/integrations/example-rust-recipe.yaml
+++ b/docs/how-to/code/integrations/example-rust-recipe.yaml
@@ -7,7 +7,7 @@ description: |
   xsv is a command line program for indexing, slicing, analyzing,
   splitting and joining CSV files. Commands should be simple, fast and
   composable.
-base: core18
+base: core22
 confinement: devmode
 
 parts:

--- a/docs/how-to/crafting/specify-a-base.rst
+++ b/docs/how-to/crafting/specify-a-base.rst
@@ -37,15 +37,6 @@ major releases support a particular base.
 
 The :ref:`reference-support-schedule` details the support timeline of each base.
 
-``core18``
-^^^^^^^^^^
-
-To build ``core18`` snaps, install snapcraft 7 from the *7.x* track:
-
-.. code-block:: bash
-
-   snap install snapcraft --channel 7.x
-
 ``core``
 ^^^^^^^^
 

--- a/docs/how-to/extensions/list-extensions.rst
+++ b/docs/how-to/extensions/list-extensions.rst
@@ -20,17 +20,15 @@ differentiating them.
 
     Extension name          Supported bases
     ----------------------  ------------------------------
-    env-injector            core24
-    flutter-beta            core18
-    flutter-dev             core18
-    flutter-master          core18
-    flutter-stable          core18
-    gnome                   core22, core24
-    gnome-3-28              core18
-    gnome-3-34              core18
-    gnome-3-38              core20
-    gpu                     core22, core24, core26
-    kde-neon                core18, core20, core22, core24
+    dotnet10              core24
+    dotnet8               core24
+    dotnet9               core24
+    env-injector          core24
+    gnome                 core22, core24
+    gpu                   core22, core24, core26
+    kde-neon              core22, core24
+    kde-neon-6            core22, core24
+    kde-neon-qt6          core22, core24
     [...]
 
 .. vale on

--- a/docs/how-to/integrations/craft-a-rust-app.rst
+++ b/docs/how-to/integrations/craft-a-rust-app.rst
@@ -45,5 +45,3 @@ To declare a Rust part:
 #. Declare the general part keys, such as ``source``, ``override-build``,
    ``build-packages``, and so on.
 #. Set ``plugin: rust``.
-#. If the snap uses core18, you can override the Rust toolchain version with
-   the ``rust-revision`` list key.

--- a/docs/how-to/integrations/craft-an-ros-1-app.rst
+++ b/docs/how-to/integrations/craft-an-ros-1-app.rst
@@ -7,7 +7,7 @@ This how-to guide covers the steps, decisions, and implementation details that a
 unique when crafting a `ROS 1 <https://wiki.ros.org/noetic>`_-based snap. We'll work
 through the aspects unique to ROS 1 apps by examining an existing project.
 
-There are two supported bases for ROS 1 -- core20 and core18.
+There are two supported bases for ROS 1 -- core20.
 
 .. tip::
 
@@ -27,36 +27,6 @@ Example project file for ROS Talker/Listener
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. tab-set::
-
-    .. tab-item:: core18
-
-        The following code comprises the project file for the `core18 version of ROS
-        Talker/Listener <https://github.com/snapcraft-docs/ros-talker-listener>`_.
-
-        .. dropdown:: Code
-
-            .. code-block:: yaml
-                :caption: snapcraft.yaml
-
-                name: ros-talker-listener
-                version: '0.1'
-                summary: ROS Talker/Listener Example
-                description: |
-                  This example launches a ROS talker and listener.
-
-                confinement: devmode
-                base: core18
-
-                parts:
-                  ros-tutorials:
-                    plugin: catkin
-                    source: https://github.com/ros/ros_tutorials.git
-                    source-branch: melodic-devel
-                    source-space: roscpp_tutorials/
-
-                apps:
-                  ros-talker-listener:
-                    command: roslaunch roscpp_tutorials talker_listener.launch
 
     .. tab-item:: core20
 

--- a/docs/how-to/integrations/craft-an-ros-2-app.rst
+++ b/docs/how-to/integrations/craft-an-ros-2-app.rst
@@ -8,7 +8,7 @@ unique when crafting a `ROS 2 <https://docs.ros.org/en/rolling/index.html>`__-ba
 snap. We'll work through the aspects unique to ROS 2 apps by examining an existing
 project.
 
-There are four supported bases for ROS 2 -- core24, core22, core20, and core18.
+There are four supported bases for ROS 2 -- core24, core22 and core20.
 
 
 .. _how-to-craft-an-ros-2-app-project-files:
@@ -17,38 +17,6 @@ Example project file for ROS 2 Talker/Listener
 ----------------------------------------------
 
 .. tab-set::
-
-    .. tab-item:: core18
-
-        The following code comprises the project file for the `core18 version of ROS 2
-        Talker/Listener <https://github.com/snapcraft-docs/ros2-talker-listener>`_.
-
-        .. dropdown:: Code
-
-            .. code-block:: yaml
-                :caption: snapcraft.yaml
-
-                name: ros2-talker-listener
-                version: '0.1'
-                summary: ROS 2 Talker/Listener Example
-                description: |
-                  This example launches a ROS 2 talker and listener.
-
-                base: core18
-                confinement: devmode
-
-                parts:
-                  ros-demos:
-                    plugin: colcon
-                    source: https://github.com/ros2/demos.git
-                    source-branch: dashing
-                    colcon-rosdistro: dashing
-                    colcon-source-space: demo_nodes_cpp
-                    stage-packages: [ros-dashing-ros2launch]
-
-                apps:
-                  ros2-talker-listener:
-                    command: opt/ros/dashing/bin/ros2 launch demo_nodes_cpp talker_listener.launch.py
 
     .. tab-item:: core20
         :sync: core20
@@ -166,8 +134,6 @@ To add an ROS 2 app:
 
       * - Core
         - Extension
-      * - core18
-        - None
       * - core20
         - :ref:`ros2-foxy <reference-ros-2-extensions>`
       * - core22
@@ -185,11 +151,6 @@ To add an ROS 2 part:
 
 #. Declare the general part keys, such as ``source``, ``override-build``,
    ``build-packages``, and so on.
-#. If you're crafting for core18, set the following special keys:
-
-   - Set ``colcon-rosdistro`` to select the ROS distribution.
-   - Set ``colcon-source-space`` to the path in the source tree where colcon packages
-     are stored.
 
 #. For ``stage-packages``, list the ROS launch command as a dependency, based
    on the core:
@@ -199,8 +160,6 @@ To add an ROS 2 part:
 
       * - Core
         - Extension
-      * - core18
-        - ros-dashing-ros2launch
       * - core20
         - ros-foxy-ros2launch
       * - core22
@@ -215,7 +174,7 @@ Handle build issues
 The following errors can occur while building for ROS 2.
 
 
-core18 and core20
+core20
 ~~~~~~~~~~~~~~~~~
 
 The warnings regarding missing libraries that you might see when building your snap are

--- a/docs/reference/bases.rst
+++ b/docs/reference/bases.rst
@@ -36,9 +36,6 @@ There are six supported base snaps:
    * - `core20`_
      - built from `Ubuntu 20.04 LTS`_
      - 8.x
-   * - `core18`_
-     - built from `Ubuntu 18.04 ESM`_
-     - 7.x
    * - `core`_
      - built from `Ubuntu 16.04 ESM`_, not to be confused with core16 (see
        below)
@@ -117,7 +114,6 @@ use ``build-base`` for kernel snaps.
 .. _`Ubuntu 24.04 LTS`: https://releases.ubuntu.com/24.04/
 .. _`Ubuntu 26.04 LTS`: https://releases.ubuntu.com/26.04/
 .. _`bare`: https://snapcraft.io/bare
-.. _`core18`: https://snapcraft.io/core18
 .. _`core20`: https://snapcraft.io/core20
 .. _`core22`: https://snapcraft.io/core22
 .. _`core24`: https://snapcraft.io/core24

--- a/docs/reference/extensions/code/flutter-extension-my-flutter-app-expanded.diff
+++ b/docs/reference/extensions/code/flutter-extension-my-flutter-app-expanded.diff
@@ -6,7 +6,7 @@
  description: |
    An example showing how Flutter programs can be packaged as snaps.
 
- base: core18
+ base: core22
  confinement: strict
  grade: stable
 

--- a/docs/reference/extensions/code/kde-neon-extension-kcalc-expanded.diff
+++ b/docs/reference/extensions/code/kde-neon-extension-kcalc-expanded.diff
@@ -6,7 +6,7 @@
  adopt-info: kcalc
 
  confinement: strict
- base: core18
+ base: core22
 
  apps:
    kcalc:
@@ -41,8 +41,8 @@
      parse-info:
        - usr/share/metainfo/org.kde.kcalc.appdata.xml
      build-snaps:
-       - kde-frameworks-5-core18-sdk
-       - kde-frameworks-5-core18
+       - kde-frameworks-5-core22-sdk
+       - kde-frameworks-5-core22
      build-packages:
        - libmpfr-dev
        - libgmp-dev
@@ -67,9 +67,9 @@
 +    build-packages:
 +      - g++
 +    build-snaps:
-+      - kde-frameworks-5-core18-sdk/latest/stable
++      - kde-frameworks-5-core22-sdk/latest/stable
 +    make-parameters:
-+      - PLATFORM_PLUG=kde-frameworks-5-core18
++      - PLATFORM_PLUG=kde-frameworks-5-core22
 +    plugin: make
 +    source: $SNAPCRAFT_EXTENSIONS_DIR/desktop
 +    source-subdir: kde-neon
@@ -83,9 +83,9 @@
 +    default-provider: gtk-common-themes
 +    interface: content
 +    target: $SNAP/data-dir/icons
-+  kde-frameworks-5-core18:
-+    content: kde-frameworks-5-core18-all
-+    default-provider: kde-frameworks-5-core18
++  kde-frameworks-5-core22:
++    content: kde-frameworks-5-core22-all
++    default-provider: kde-frameworks-5-core22
 +    interface: content
 +    target: $SNAP/kf5
 +  sound-themes:

--- a/docs/reference/extensions/flutter-extension.rst
+++ b/docs/reference/extensions/flutter-extension.rst
@@ -8,9 +8,7 @@ the `Flutter <https://flutter.dev>`__ framework.
 
 .. SNAPCRAFT-1123: Missing link to Flutter plugin.
 
-The Flutter extensions require Snapcraft 7 and lower and are currently only supported
-with the core18 base. Snaps using cores higher than core18 should instead use the
-Flutter plugin with the :ref:`reference-gnome-extension`.
+Snaps should use the Flutter plugin with the :ref:`reference-gnome-extension`.
 
 There are four extensions in the family. Each tracks a different `Flutter build release
 channel


### PR DESCRIPTION
Fixes #6270

Removed references to core18, and replaced core18 to core22 in how-to and references.

### NOTE
- In `/docs/how-to/extensions/list-extensions.rst`, I replaced snippet with snippet of actual output of `snapcraft extensions`.
- These files were not changed. They seem to reference to release information. `/docs/how-to/change-bases/change-from-core18-to-core20.rst`, `/docs/how-to/change-bases/index.rst`, `/docs/_static/js/support-chart.js`, `/docs/index.rst`

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [x] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
