### PR TITLE
docs: fix version numbering

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,12 +26,13 @@ import snapcraft
 project = "Snapcraft"
 author = "Canonical Ltd."
 
-# Sidebar documentation title; best kept reasonably short
-# The full version, including alpha/beta/rc tags
-release = snapcraft.__version__
-if ".post" in release:
-    release = "dev"
+# Version string in sidebar
+if os.environ.get("READTHEDOCS_VERSION_TYPE", "external") != "external":
+    rtd_version = os.environ.get("READTHEDOCS_VERSION", "latest")
+    release = rtd_version if rtd_version != "latest" else "dev"
 else:
+    release = snapcraft.__version__
+    # Because of Autotools, we can safely assume the version starts with `n.n`
     major, minor, *_ = release.split(".")
     release = f"{major}.{minor}"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,9 +31,8 @@ if os.environ.get("READTHEDOCS_VERSION_TYPE", "external") != "external":
     rtd_version = os.environ.get("READTHEDOCS_VERSION", "latest")
     release = rtd_version if rtd_version != "latest" else "dev"
 else:
-    release = snapcraft.__version__
     # Because of Autotools, we can safely assume the version starts with `n.n`
-    major, minor, *_ = release.split(".")
+    major, minor, *_ = snapcraft.__version__.split(".")
     release = f"{major}.{minor}"
 
 # Copyright string; shown at the bottom of the page

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,13 +27,13 @@ project = "Snapcraft"
 author = "Canonical Ltd."
 
 # Version string in sidebar
-if os.environ.get("READTHEDOCS_VERSION_TYPE", "external") != "external":
-    rtd_version = os.environ.get("READTHEDOCS_VERSION", "latest")
-    release = rtd_version if rtd_version != "latest" else "dev"
-else:
+if os.environ.get("READTHEDOCS_VERSION_TYPE", "external") == "external":  # PR or local build
     # Because of Autotools, we can safely assume the version starts with `n.n`
     major, minor, *_ = snapcraft.__version__.split(".")
     release = f"{major}.{minor}"
+else:  # Branch build
+    rtd_version = os.environ.get("READTHEDOCS_VERSION", "latest")
+    release = "dev" if rtd_version == "latest" else rtd_version
 
 # Copyright string; shown at the bottom of the page
 copyright = "2015-%s, %s" % (datetime.date.today().year, author)


### PR DESCRIPTION
With the new release policy, the RTD version is based on branches, not tags. So, in the RTD environment we need to rely on different data, and the local builds should match it so the results are the same.

Tested locally with the following RTD environment values.

Main branch:

```
os.environ["READTHEDOCS_VERSION"] = "latest"
os.environ["READTHEDOCS_VERSION_TYPE"] = "branch"
os.environ["READTHEDOCS_GIT_IDENTIFIER"] = "main"
```

Hotfix branch:

```
os.environ["READTHEDOCS_VERSION"] = "9.0"
os.environ["READTHEDOCS_VERSION_TYPE"] = "branch"
os.environ["READTHEDOCS_GIT_IDENTIFIER"] = "hotfix/9.0"
```

PR branch:

```
os.environ["READTHEDOCS_VERSION"] = "1357"
os.environ["READTHEDOCS_VERSION_TYPE"] = "external"
os.environ["READTHEDOCS_GIT_IDENTIFIER"] = "my-fork/my-branch"
```

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
