### PR TITLE
feat: deprecate 'ua-services' key for core24+

### DIFF
--- a/schema/snapcraft.json
+++ b/schema/snapcraft.json
@@ -1650,6 +1650,7 @@
             }
           ],
           "default": null,
+          "deprecated": true,
           "description": "The Ubuntu Pro (formerly Ubuntu Advantage) services to enable when building the snap.",
           "examples": ["[esm-apps]"],
           "title": "Ua-Services"
@@ -2236,6 +2237,7 @@
             }
           ],
           "default": null,
+          "deprecated": true,
           "description": "The Ubuntu Pro (formerly Ubuntu Advantage) services to enable when building the snap.",
           "examples": ["[esm-apps]"],
           "title": "Ua-Services"
@@ -2812,6 +2814,7 @@
             }
           ],
           "default": null,
+          "deprecated": true,
           "description": "The Ubuntu Pro (formerly Ubuntu Advantage) services to enable when building the snap.",
           "examples": ["[esm-apps]"],
           "title": "Ua-Services"
@@ -4144,6 +4147,7 @@
             }
           ],
           "default": null,
+          "deprecated": true,
           "description": "The Ubuntu Pro (formerly Ubuntu Advantage) services to enable when building the snap.",
           "examples": ["[esm-apps]"],
           "title": "Ua-Services"
@@ -4739,6 +4743,7 @@
             }
           ],
           "default": null,
+          "deprecated": true,
           "description": "The Ubuntu Pro (formerly Ubuntu Advantage) services to enable when building the snap.",
           "examples": ["[esm-apps]"],
           "title": "Ua-Services"
@@ -5315,6 +5320,7 @@
             }
           ],
           "default": null,
+          "deprecated": true,
           "description": "The Ubuntu Pro (formerly Ubuntu Advantage) services to enable when building the snap.",
           "examples": ["[esm-apps]"],
           "title": "Ua-Services"

--- a/snapcraft/models/project.py
+++ b/snapcraft/models/project.py
@@ -1900,6 +1900,9 @@ class Project(models.Project):
 
     Enabling `Ubuntu Pro <https://ubuntu.com/pro>`_ services allows building
     snaps in an Ubuntu Pro enabled environment.
+
+    This is only available for core22 snaps. Core24 and higher snaps should specify Pro
+    services with the command-line argument ``--pro=<services>`` instead.
     """
 
     provenance: str | None = pydantic.Field(
@@ -2482,6 +2485,16 @@ class Core24Project(StableBaseProject):
         examples=[
             "{amd64: {build-on: [amd64], build-for: [amd64]}, arm64: {build-on: [amd64, arm64], build-for: [arm64]}}"
         ],
+    )
+
+    ua_services: set[str] | None = pydantic.Field(
+        default=None,
+        description="The Ubuntu Pro (formerly Ubuntu Advantage) services to enable when building the snap.",
+        examples=["[esm-apps]"],
+        deprecated=(
+            "The 'ua-services' key is ignored for core24 and higher snaps. Specify Pro "
+            "services with the command-line argument ``--pro=<services>`` instead."
+        ),
     )
 
 

--- a/snapcraft/services/project.py
+++ b/snapcraft/services/project.py
@@ -23,6 +23,7 @@ import craft_platforms
 import craft_providers.bases
 from craft_application import ProjectService
 from craft_application.errors import CraftValidationError
+from craft_application.util import is_managed_mode
 from typing_extensions import override
 
 from snapcraft.extensions import apply_extensions
@@ -47,6 +48,9 @@ class Project(ProjectService):
 
     __project_file_path: pathlib.Path | None = None
 
+    # Used to only issue a warning once.
+    _ua_service_warning: bool = False
+
     @staticmethod
     @override
     def _app_preprocess_project(
@@ -60,9 +64,38 @@ class Project(ProjectService):
         # craft-parts doesn't allow `parse-info` in parts
         extract_parse_info(project)
         apply_root_packages(project)
+        Project.validate_ua_services(project)
 
     def get_parse_info(self) -> dict[str, list[str]]:
         return extract_parse_info(self.get_raw())
+
+    @staticmethod
+    def validate_ua_services(project: dict[str, Any]) -> None:
+        """Warn if the 'ua-services' key is used for a base other than core22.
+
+        This warning is only shown once - either before launching a managed instance
+        or in destructive mode.
+        """
+        # one-shot
+        if Project._ua_service_warning:
+            return
+        Project._ua_service_warning = True
+
+        if is_managed_mode():
+            return
+
+        base = get_effective_base(
+            base=project.get("base"),
+            build_base=project.get("build-base"),
+            project_type=project.get("type"),
+            name=project.get("name"),
+            translate_devel=True,
+        )
+        if base is not None and base != "core22" and project.get("ua-services"):
+            craft_cli.emit.warning(
+                f"The 'ua-services' key is ignored for {base!r}. "
+                "Use '--pro=<services>' instead."
+            )
 
     @override
     def resolve_project_file_path(self) -> pathlib.Path:

--- a/snapcraft/services/project.py
+++ b/snapcraft/services/project.py
@@ -69,17 +69,17 @@ class Project(ProjectService):
     def get_parse_info(self) -> dict[str, list[str]]:
         return extract_parse_info(self.get_raw())
 
-    @staticmethod
-    def validate_ua_services(project: dict[str, Any]) -> None:
+    @classmethod
+    def validate_ua_services(cls, project: dict[str, Any]) -> None:
         """Warn if the 'ua-services' key is used for a base other than core22.
 
         This warning is shown no more than once - either before launching a managed
         instance or in destructive mode.
         """
         # one-shot
-        if Project._ua_service_warning:
+        if cls._ua_service_warning:
             return
-        Project._ua_service_warning = True
+        cls._ua_service_warning = True
 
         if is_managed_mode():
             return

--- a/snapcraft/services/project.py
+++ b/snapcraft/services/project.py
@@ -73,8 +73,8 @@ class Project(ProjectService):
     def validate_ua_services(project: dict[str, Any]) -> None:
         """Warn if the 'ua-services' key is used for a base other than core22.
 
-        This warning is only shown once - either before launching a managed instance
-        or in destructive mode.
+        This warning is shown no more than once - either before launching a managed
+        instance or in destructive mode.
         """
         # one-shot
         if Project._ua_service_warning:

--- a/tests/unit/services/test_project.py
+++ b/tests/unit/services/test_project.py
@@ -29,6 +29,14 @@ from snapcraft.application import APP_METADATA
 from snapcraft.services.project import Project
 
 
+@pytest.fixture(autouse=True)
+def reset_ua_service_warning():
+    """Reset the one-shot ua-service warning flag between tests."""
+    Project._ua_service_warning = False
+    yield
+    Project._ua_service_warning = False
+
+
 @pytest.mark.parametrize(
     ("raw_project", "expected"),
     [
@@ -106,3 +114,47 @@ def test_render_legacy_platforms_core22_platforms_error(
 
     with pytest.raises(CraftValidationError, match="not supported for base 'core22'"):
         service._app_render_legacy_platforms()
+
+
+class TestValidateUaServices:
+    @pytest.mark.parametrize("base", const.CURRENT_BASES - {"core22"})
+    def test_warns_for_ua_services(self, base, emitter):
+        """Warn for using 'ua-services' on core24+."""
+        project = {"base": base, "ua-services": ["esm-apps"]}
+
+        Project.validate_ua_services(project)
+        Project.validate_ua_services(project)
+
+        emitter.assert_warning(
+            f"The 'ua-services' key is ignored for {base!r}. "
+            "Use '--pro=<services>' instead."
+        )
+        # assert it was only shown once
+        assert len(emitter.interactions) == 1
+
+    @pytest.mark.parametrize("base", const.CURRENT_BASES)
+    def test_no_warning_without_ua_services(self, base, emitter):
+        """Don't warn if 'ua-services' isn't defined."""
+        project = {"base": base}
+
+        Project.validate_ua_services(project)
+
+        emitter.assert_interactions(None)
+
+    @pytest.mark.parametrize("base", const.CURRENT_BASES)
+    def test_no_warning_in_managed_mode(self, base, emitter, mocker):
+        """Don't warn in managed-mode."""
+        mocker.patch("snapcraft.services.project.is_managed_mode", return_value=True)
+        project = {"base": base, "ua-services": ["esm-apps"]}
+
+        Project.validate_ua_services(project)
+
+        emitter.assert_interactions(None)
+
+    def test_no_warning_for_core22(self, emitter):
+        """Don't warn for using 'ua-services' on core2."""
+        project = {"base": "core22", "ua-services": ["esm-apps"]}
+
+        Project.validate_ua_services(project)
+
+        emitter.assert_interactions(None)

--- a/tests/unit/services/test_project.py
+++ b/tests/unit/services/test_project.py
@@ -152,7 +152,7 @@ class TestValidateUaServices:
         emitter.assert_interactions(None)
 
     def test_no_warning_for_core22(self, emitter):
-        """Don't warn for using 'ua-services' on core2."""
+        """Don't warn for using 'ua-services' on core22."""
         project = {"base": "core22", "ua-services": ["esm-apps"]}
 
         Project.validate_ua_services(project)


### PR DESCRIPTION
Deprecates and warns when using `ua-services` for core24 and higher bases.

This has been replaced in core24+ by the new `--pro=<services>` command-line argument.

(CRAFT-5217)

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
