### PR TITLE
docs: document where to find changelog for base snaps

### DIFF
--- a/docs/how-to/change-bases/index.rst
+++ b/docs/how-to/change-bases/index.rst
@@ -76,8 +76,8 @@ When the snap is already installed
 If the base snap is already installed on the system, the changelog is available
 at ``/snap/<base>/current/usr/share/doc/ChangeLog``.
 
-You can list all installed revisions and versions with ``snap list --all <base>``.
-To inspect a specific revision that is not the active one, replace ``current`` with
+You can list all installed revisions and versions of a base with ``snap list --all <base>``.
+To inspect a specific revision, replace ``current`` with
 the revision number. For example, ``/snap/<base>/<revision>/usr/share/doc/ChangeLog``.
 
 

--- a/docs/how-to/change-bases/index.rst
+++ b/docs/how-to/change-bases/index.rst
@@ -1,3 +1,6 @@
+.. meta::
+    :description: How to change the base snap of a snap and access its ChangeLog.
+
 .. _how-to-change-bases:
 
 Change bases
@@ -55,3 +58,42 @@ transition your snap between specific bases.
     change-from-core20-to-core22
     change-from-core22-to-core24
     change-from-core24-to-core26
+
+
+ChangeLog for base snaps
+-------------------------
+
+Each release of the base snap includes a ChangeLog at
+``/usr/share/doc/ChangeLog`` that summarises the package updates bundled in
+that release, along with the aggregated updates from previous releases.
+In the examples below, replace ``<base>`` with the name of
+your base snap (for example, ``core24``). Note that ``core26`` does not
+currently include a ChangeLog.
+
+
+When the snap is already installed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the base snap is already installed on the system, the ChangeLog is available
+at ``/snap/<base>/current/usr/share/doc/ChangeLog``.
+
+You can list all installed revisions with ``snap list --all <base>``. To inspect
+a specific revision that is not the active one, replace ``current`` with the
+revision number (e.g. ``/snap/<base>/<revision>/usr/share/doc/ChangeLog``).
+
+
+Via ``snap download``
+~~~~~~~~~~~~~~~~~~~~~
+
+You can download a snap without installing it, then extract the
+ChangeLog from the squashfs image:
+
+.. code-block:: bash
+
+    # Download the snap
+    snap download <base>
+
+    # Extract the ChangeLog into a local directory
+    unsquashfs -d <base>-unpacked <base>_*.snap usr/share/doc/ChangeLog
+
+The ChangeLog is then available at ``<base>-unpacked/usr/share/doc/ChangeLog``.

--- a/docs/how-to/change-bases/index.rst
+++ b/docs/how-to/change-bases/index.rst
@@ -1,5 +1,5 @@
 .. meta::
-    :description: How to change the base snap of a snap and access its ChangeLog.
+    :description: How to change the base of a snap. Switch between bases like core24 to core26. This guide describes the different requirements of each migration path.
 
 .. _how-to-change-bases:
 
@@ -60,40 +60,36 @@ transition your snap between specific bases.
     change-from-core24-to-core26
 
 
-ChangeLog for base snaps
--------------------------
+Base changelogs
+---------------
 
-Each release of the base snap includes a ChangeLog at
-``/usr/share/doc/ChangeLog`` that summarises the package updates bundled in
-that release, along with the aggregated updates from previous releases.
+Each base snap contains a changelog at ``/usr/share/doc/ChangeLog``
+that summarizes the package updates bundled in that release,
+along with the aggregated updates from previous releases.
 In the examples below, replace ``<base>`` with the name of
-your base snap (for example, ``core24``). Note that ``core26`` does not
-currently include a ChangeLog.
+your base snap (for example, core24).
 
 
 When the snap is already installed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If the base snap is already installed on the system, the ChangeLog is available
+If the base snap is already installed on the system, the changelog is available
 at ``/snap/<base>/current/usr/share/doc/ChangeLog``.
 
-You can list all installed revisions with ``snap list --all <base>``. To inspect
-a specific revision that is not the active one, replace ``current`` with the
-revision number (e.g. ``/snap/<base>/<revision>/usr/share/doc/ChangeLog``).
+You can list all installed revisions and versions with ``snap list --all <base>``.
+To inspect a specific revision that is not the active one, replace ``current`` with
+the revision number. For example, ``/snap/<base>/<revision>/usr/share/doc/ChangeLog``.
 
 
-Via ``snap download``
-~~~~~~~~~~~~~~~~~~~~~
+Download a base
+~~~~~~~~~~~~~~~
 
-You can download a snap without installing it, then extract the
-ChangeLog from the squashfs image:
+You can download a base without installing it, then extract the
+changelog from it:
 
 .. code-block:: bash
 
-    # Download the snap
     snap download <base>
-
-    # Extract the ChangeLog into a local directory
     unsquashfs -d <base>-unpacked <base>_*.snap usr/share/doc/ChangeLog
 
-The ChangeLog is then available at ``<base>-unpacked/usr/share/doc/ChangeLog``.
+The changelog is then available at ``<base>-unpacked/usr/share/doc/ChangeLog``.


### PR DESCRIPTION
[SNAPDENG-37127](https://warthogs.atlassian.net/browse/SNAPDENG-37127)
Related
* core18: https://github.com/canonical/core18/pull/203
* core20: https://github.com/canonical/core20/pull/184
* core22: https://github.com/canonical/core-base/pull/451
* core24: https://github.com/canonical/core-base/pull/452
* ubuntu-core-docs: https://github.com/canonical/ubuntu-core-docs/pull/379

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make docs && make lint-docs`.
- [x] I've added or updated any relevant documentation.
- [x] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.


[SNAPDENG-37127]: https://warthogs.atlassian.net/browse/SNAPDENG-37127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ