### PR TITLE
fix(extensions/ros): fix ros 2 extension core26

### DIFF
--- a/extensions/ros1/Makefile
+++ b/extensions/ros1/Makefile
@@ -1,8 +1,12 @@
 #!/usr/bin/make -f
 
+# The make plugin runs `make` (default goal) before `make install DESTDIR=...`.
+# Keep the default goal a no-op so install only runs with a populated DESTDIR.
+all:
+
 install:
 	install -D -m755 launch "$(DESTDIR)"/snap/command-chain/ros1-launch
 	install -D -m755 roslaunch "$(DESTDIR)"/roslaunch
 	install -D -m755 rosrun "$(DESTDIR)"/rosrun
 
-.PHONY: launch roslaunch rosrun
+.PHONY: all install

--- a/extensions/ros1/Makefile
+++ b/extensions/ros1/Makefile
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 # The make plugin runs `make` (default goal) before `make install DESTDIR=...`.
-# Keep the default goal a no-op so install only runs with a populated DESTDIR.
+# Keep the default goal a no-op so the initial bare `make` doesn't run `install` with an empty DESTDIR
 all:
 
 install:

--- a/extensions/ros2/Makefile
+++ b/extensions/ros2/Makefile
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 # The make plugin runs `make` (default goal) before `make install DESTDIR=...`.
-# Keep the default goal a no-op so install only runs with a populated DESTDIR.
+# Keep the default goal a no-op so the initial bare `make` doesn't run `install` with an empty DESTDIR.
 all:
 
 install:

--- a/extensions/ros2/Makefile
+++ b/extensions/ros2/Makefile
@@ -1,7 +1,11 @@
 #!/usr/bin/make -f
 
+# The make plugin runs `make` (default goal) before `make install DESTDIR=...`.
+# Keep the default goal a no-op so install only runs with a populated DESTDIR.
+all:
+
 install:
 	install -D -m755 launch "$(DESTDIR)"/snap/command-chain/ros2-launch
 	install -D -m755 ros2 "$(DESTDIR)"/ros2
 
-.PHONY: launch ros2
+.PHONY: all install

--- a/extensions/ros2/launch
+++ b/extensions/ros2/launch
@@ -14,12 +14,6 @@ function source_with_prefix() {
 # Save off parameters, the sourced setup scripts may manipulate them.
 original_args=("$@")
 
-if [ -d "$SNAP/opt/ros/underlay_ws/opt/ros/$ROS_DISTRO" ]; then
-  source_with_prefix "$SNAP/opt/ros/underlay_ws/opt/ros/$ROS_DISTRO"
-fi
-if [ -d "$SNAP/opt/ros/underlay_ws/opt/ros/snap" ]; then
-  source_with_prefix "$SNAP/opt/ros/underlay_ws/opt/ros/snap"
-fi
 if [ -d "$SNAP/opt/ros/underlay_ws/opt/ros/$ROS_DISTRO" ] || [ -d "$SNAP/opt/ros/underlay_ws/opt/ros/snap" ]; then
 
   case "$SNAP_ARCH" in
@@ -37,6 +31,15 @@ if [ -d "$SNAP/opt/ros/underlay_ws/opt/ros/$ROS_DISTRO" ] || [ -d "$SNAP/opt/ros
 
   export PATH="$SNAP/opt/ros/underlay_ws/usr/bin:$PATH"
   export LD_LIBRARY_PATH="$SNAP/opt/ros/underlay_ws/usr/lib:$SNAP/opt/ros/underlay_ws/usr/lib/$ARCH_TRIPLET:$LD_LIBRARY_PATH"
+fi
+
+# The sourcing happens after the PATH and LD_LIBRARY_PATH are set,
+# so that the local_setup.bash scripts can find the correct python3 with content sharing.
+if [ -d "$SNAP/opt/ros/underlay_ws/opt/ros/$ROS_DISTRO" ]; then
+  source_with_prefix "$SNAP/opt/ros/underlay_ws/opt/ros/$ROS_DISTRO"
+fi
+if [ -d "$SNAP/opt/ros/underlay_ws/opt/ros/snap" ]; then
+  source_with_prefix "$SNAP/opt/ros/underlay_ws/opt/ros/snap"
 fi
 
 source_with_prefix "$SNAP/opt/ros/$ROS_DISTRO"

--- a/snapcraft/extensions/_ros2_lyrical_meta.py
+++ b/snapcraft/extensions/_ros2_lyrical_meta.py
@@ -113,7 +113,7 @@ class ROS2LyricalMetaBase(ROS2LyricalExtension):
             f"ros-{self.ROS_DISTRO}-ros-workspace",
             f"ros-{self.ROS_DISTRO}-ament-index-cpp",
             f"ros-{self.ROS_DISTRO}-ament-index-python",
-        ] + parts_snippet[f"ros2-{self.ROS_DISTRO}/ros2-launch"]["stage-packages"]
+        ]
 
         # Something in the ROS 2 build chain requires to find this lib during cmake call,
         # however its cmake files ship with the '-dev' package.

--- a/snapcraft/extensions/ros2_lyrical.py
+++ b/snapcraft/extensions/ros2_lyrical.py
@@ -132,6 +132,6 @@ class ROS2LyricalExtension(Extension):
                     f"ros-{self.ROS_DISTRO}-ros-workspace",
                     f"ros-{self.ROS_DISTRO}-ament-index-cpp",
                     f"ros-{self.ROS_DISTRO}-ament-index-python",
-                ]
+                ],
             }
         }

--- a/snapcraft/extensions/ros2_lyrical.py
+++ b/snapcraft/extensions/ros2_lyrical.py
@@ -132,14 +132,6 @@ class ROS2LyricalExtension(Extension):
                     f"ros-{self.ROS_DISTRO}-ros-workspace",
                     f"ros-{self.ROS_DISTRO}-ament-index-cpp",
                     f"ros-{self.ROS_DISTRO}-ament-index-python",
-                ],
-                "stage-packages": [
-                    "libpython3.14-minimal",
-                    "libpython3.14-stdlib",
-                    "python3-minimal",  # for the "python3" symlink
-                    "python3.14-minimal",
-                    "python3.14-venv",
-                    "python3-yaml",
-                ],
+                ]
             }
         }

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,5 +1,7 @@
 project: snapcraft
 
+kill-timeout: 90m
+
 environment:
   # Tell snapcraft to use the current host to build
   SNAPCRAFT_BUILD_ENVIRONMENT: "host"
@@ -112,6 +114,10 @@ backends:
           username: root
           password: ubuntu
       - ubuntu-24.04-64:
+          workers: 1
+          username: root
+          password: ubuntu
+      - ubuntu-26.04-64:
           workers: 1
           username: root
           password: ubuntu

--- a/tests/spread/extensions/ros2-jazzy-meta-talker-listener/task.yaml
+++ b/tests/spread/extensions/ros2-jazzy-meta-talker-listener/task.yaml
@@ -38,7 +38,7 @@ prepare: |
   sed -i "s|core22|core24|" "$SNAP_DIR/snap/snapcraft.yaml"
 
   # Overwrite the extension to test them all out of a single snap
-  sed -i "s|ros2-jazzy|${EXTENSION}|" "$SNAP_DIR/snap/snapcraft.yaml"
+  sed -i "s|ros2-humble|${EXTENSION}|" "$SNAP_DIR/snap/snapcraft.yaml"
 
   #shellcheck source=tests/spread/tools/package-utils.sh
   . "$TOOLS_DIR/package-utils.sh"

--- a/tests/spread/extensions/ros2-lyrical-hello/task.yaml
+++ b/tests/spread/extensions/ros2-lyrical-hello/task.yaml
@@ -11,6 +11,7 @@ systems:
   - ubuntu-26.04-arm64
 
 environment:
+  SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "1"
 
   SNAP_DIR: ../snaps/ros2-lyrical-hello
   SNAP: ros2-lyrical-hello

--- a/tests/spread/extensions/ros2-lyrical-hello/task.yaml
+++ b/tests/spread/extensions/ros2-lyrical-hello/task.yaml
@@ -42,6 +42,10 @@ restore: |
   dpkg_restore_point
 
 execute: |
+  # Unset SNAPCRAFT_BUILD_ENVIRONMENT=host to avoid building core26
+  # snap with core24 which has libapt 2 and can't read the cache on 26.04.
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+
   cd "${SNAP_DIR}"
 
   # Make sure expand-extensions works

--- a/tests/spread/extensions/ros2-lyrical-meta-hello/task.yaml
+++ b/tests/spread/extensions/ros2-lyrical-meta-hello/task.yaml
@@ -65,6 +65,10 @@ restore: |
   snap remove --purge "${META_SNAP}"
 
 execute: |
+  # Unset SNAPCRAFT_BUILD_ENVIRONMENT=host to avoid building core26
+  # snap with core24 which has libapt 2 and can't read the cache on 26.04.
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+
   cd "$SNAP_DIR"
 
   # Build what we have and verify the snap runs as expected.

--- a/tests/spread/extensions/ros2-lyrical-meta-talker-listener/task.yaml
+++ b/tests/spread/extensions/ros2-lyrical-meta-talker-listener/task.yaml
@@ -60,6 +60,10 @@ restore: |
   snap remove --purge "${META_SNAP}"
 
 execute: |
+  # Unset SNAPCRAFT_BUILD_ENVIRONMENT=host to avoid building core26
+  # snap with core24 which has libapt 2 and can't read the cache on 26.04.
+  unset SNAPCRAFT_BUILD_ENVIRONMENT
+
   cd "$SNAP_DIR"
 
   # Build what we have and verify the snap runs as expected.

--- a/tests/spread/extensions/snaps/ros2-lyrical-hello/CMakeLists.txt
+++ b/tests/spread/extensions/snaps/ros2-lyrical-hello/CMakeLists.txt
@@ -24,8 +24,7 @@ if(NOT WIN32)
 endif()
 
 add_executable(colcon_ros2_rlcpp_hello src/hello.cpp)
-target_link_libraries(colcon_ros2_rlcpp_hello)
-ament_target_dependencies(colcon_ros2_rlcpp_hello rclcpp class_loader)
+target_link_libraries(colcon_ros2_rlcpp_hello rclcpp::rclcpp)
 
 install(TARGETS
   colcon_ros2_rlcpp_hello

--- a/tests/spread/plugins/craft-parts/colcon-talker-listener/colcon-talker-listener/CMakeLists.txt
+++ b/tests/spread/plugins/craft-parts/colcon-talker-listener/colcon-talker-listener/CMakeLists.txt
@@ -22,10 +22,15 @@ if(NOT WIN32)
 endif()
 
 add_executable(talker src/publisher_member_function.cpp)
-ament_target_dependencies(talker rclcpp std_msgs)
-
 add_executable(listener src/subscriber_member_function.cpp)
-ament_target_dependencies(listener rclcpp std_msgs)
+
+if(COMMAND ament_target_dependencies)
+  ament_target_dependencies(talker rclcpp std_msgs)
+  ament_target_dependencies(listener rclcpp std_msgs)
+else()
+  target_link_libraries(talker rclcpp::rclcpp ${std_msgs_TARGETS})
+  target_link_libraries(listener rclcpp::rclcpp ${std_msgs_TARGETS})
+endif()
 
 install(
   TARGETS talker listener

--- a/tests/unit/parts/extensions/test_ros2_lyrical.py
+++ b/tests/unit/parts/extensions/test_ros2_lyrical.py
@@ -147,13 +147,5 @@ class TestExtensionROS2LyricalExtension:
                     "ros-lyrical-ament-index-cpp",
                     "ros-lyrical-ament-index-python",
                 ],
-                "stage-packages": [
-                    "libpython3.14-minimal",
-                    "libpython3.14-stdlib",
-                    "python3-minimal",
-                    "python3.14-minimal",
-                    "python3.14-venv",
-                    "python3-yaml",
-                ],
             }
         }

--- a/tests/unit/parts/extensions/test_ros2_lyrical_meta.py
+++ b/tests/unit/parts/extensions/test_ros2_lyrical_meta.py
@@ -202,12 +202,6 @@ class TestExtensionROS2LyricalMetaExtensions:
                     "ros-lyrical-ros-workspace",
                     "ros-lyrical-ament-index-cpp",
                     "ros-lyrical-ament-index-python",
-                    "libpython3.14-minimal",
-                    "libpython3.14-stdlib",
-                    "python3-minimal",
-                    "python3.14-minimal",
-                    "python3.14-venv",
-                    "python3-yaml",
                 ],
             }
         }


### PR DESCRIPTION
-  Add a no-op all: default target to the shared ROS 2 launch Makefile so the [make plugin](https://github.com/canonical/craft-parts/blob/main/craft_parts/plugins/make_plugin.py#L92-L98)'s first invocation (bare make, run before make install) no longer triggers the install recipe with an empty `DESTDIR`.
   On core26 this is causing the following failure:
   ```
    :: + make -j24
    :: install -D -m755 launch ""/snap/command-chain/ros2-launch
    :: install -D -m755 ros2 ""/ros2
    :: install: No such file or directory
    :: make: *** [Makefile:5: install] Error 1
    ```
    On core26 the base ships uutils coreutils instead of GNU coreutils. With install as the default target, the first run executed `install -D -m755 ros2 "$(DESTDIR)"/ros2` with an empty `DESTDIR`, resolving to `/ros2`, destination whose parent is the filesystem root /. An issue with coreutils https://github.com/uutils/coreutils/issues/13232 makes the file disappear from the expected location. That was not happening in core24.
   Also change the phony targets to match the makefile commands as specified in the https://ftp.gnu.org/old-gnu/Manuals/make-3.79.1/html_node/make_34.html.

-   This PR also reorders the shared ROS 2 launch command-chain script so the underlay's PATH/LD_LIBRARY_PATH exports run before the underlay ROS 2 workspaces are sourced, instead of after. On core26 a minimal content-sharing (meta) snap fails at runtime with: 
    ```
    env: 'python3': No such file or directory
    env: use -[v]S to pass options in shebang lines
    error: unable to find fallback python3 executable
    error: unable to find python3 executable
    ```
    When sourcing local_setup.bash itt shells out to python3 to run _local_setup_util.py (#!/usr/bin/env python3) to compute the ordered environment. So entering any ROS 2 workspace requires python3 on `PATH` at source time, even for a C++ node.  For a content-sharing meta snap the only python3 lives in the underlay at `$SNAP/opt/ros/underlay_ws/usr/bin`, hence the sourcing must be done after the PATH is updated.  This did not surface on core22 (humble) or core24 (jazzy) because those bases ship /usr/bin/python3 (python3.10 / python3.12).
- Fixes on spread tests for core26.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [x] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [x] I've updated the relevant release notes.
