### PR TITLE
feat: error when --pro is used for core22

### DIFF
--- a/snapcraft/commands/core22/lifecycle.py
+++ b/snapcraft/commands/core22/lifecycle.py
@@ -31,6 +31,16 @@ from snapcraft import errors, pack, utils
 from snapcraft.parts import lifecycle as parts_lifecycle
 
 
+def _validate_pro(parsed_args: argparse.Namespace) -> None:
+    """Error if '--pro' was provided."""
+    if getattr(parsed_args, "pro", None) is not None:
+        raise errors.SnapcraftError(
+            "'--pro' is not supported for core22.",
+            resolution="Use the 'ua-services' key in the project file instead.",
+            doc_slug="/reference/snapcraft-yaml/#ua-services",
+        )
+
+
 class _LifecycleCommand(BaseCommand, abc.ABC):
     """Lifecycle-related commands."""
 
@@ -107,12 +117,19 @@ class _LifecycleCommand(BaseCommand, abc.ABC):
             default=os.getenv("SNAPCRAFT_ENABLE_EXPERIMENTAL_PLUGINS", "") != "",
             help="Allow using experimental (unstable) plugins.",
         )
+        parser.add_argument(
+            "--pro",
+            type=str,
+            help=argparse.SUPPRESS,
+        )
 
     @override
     def run(self, parsed_args: argparse.Namespace):
         """Run the command."""
         if not self.name:
             raise RuntimeError("command name not specified")
+
+        _validate_pro(parsed_args)
 
         emit.debug(f"lifecycle command: {self.name!r}, arguments: {parsed_args!r}")
         parts_lifecycle.run(self.name, parsed_args)
@@ -237,6 +254,7 @@ class PackCommand(_LifecycleCommand):
     def run(self, parsed_args: argparse.Namespace):
         """Run the command."""
         if parsed_args.directory:
+            _validate_pro(parsed_args)
             snap_filename = pack.pack_snap(
                 parsed_args.directory, output=parsed_args.output
             )

--- a/tests/unit/cli/test_default_command.py
+++ b/tests/unit/cli/test_default_command.py
@@ -42,6 +42,7 @@ def test_default_command(mocker):
                 build_for=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 http_proxy=None,
                 https_proxy=None,
             )
@@ -68,6 +69,7 @@ def test_default_command_destructive_mode(mocker):
                 build_for=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 http_proxy=None,
                 https_proxy=None,
             )
@@ -94,6 +96,7 @@ def test_default_command_use_lxd(mocker):
                 build_for=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 http_proxy=None,
                 https_proxy=None,
             )
@@ -121,6 +124,7 @@ def test_default_command_output(mocker, option):
                 build_for=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 http_proxy=None,
                 https_proxy=None,
             )
@@ -142,6 +146,7 @@ def test_default_command_http_proxy(mocker):
                 directory=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 enable_manifest=False,
                 http_proxy="test-http",
                 https_proxy=None,
@@ -168,6 +173,7 @@ def test_default_command_https_proxy(mocker):
                 directory=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 enable_manifest=False,
                 http_proxy=None,
                 https_proxy="test-https",

--- a/tests/unit/cli/test_lifecycle.py
+++ b/tests/unit/cli/test_lifecycle.py
@@ -53,6 +53,7 @@ def test_lifecycle_command(cmd, run_method, mocker):
                 build_for=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 http_proxy=None,
                 https_proxy=None,
             )
@@ -98,6 +99,7 @@ def test_lifecycle_command_arguments(cmd, run_method, mocker):
                 build_for=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 http_proxy=None,
                 https_proxy=None,
             )
@@ -144,6 +146,7 @@ def test_lifecycle_command_arguments_destructive_mode(cmd, run_method, mocker):
                 build_for=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 http_proxy=None,
                 https_proxy=None,
             )
@@ -190,6 +193,7 @@ def test_lifecycle_command_arguments_use_lxd(cmd, run_method, mocker):
                 build_for=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 http_proxy=None,
                 https_proxy=None,
             )
@@ -233,6 +237,7 @@ def test_lifecycle_command_arguments_bind_ssh(cmd, run_method, mocker):
                 ua_token=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 parts=[],
                 shell=False,
                 shell_after=False,
@@ -280,6 +285,7 @@ def test_lifecycle_command_arguments_ua_token(cmd, run_method, mocker):
                 build_for=None,
                 enable_experimental_ua_services=True,
                 enable_experimental_plugins=False,
+                pro=None,
                 http_proxy=None,
                 https_proxy=None,
             )
@@ -324,6 +330,7 @@ def test_lifecycle_command_arguments_debug(cmd, run_method, mocker):
                 build_for=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 http_proxy=None,
                 https_proxy=None,
             )
@@ -368,6 +375,7 @@ def test_lifecycle_command_arguments_shell(cmd, run_method, mocker):
                 build_for=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 http_proxy=None,
                 https_proxy=None,
             )
@@ -412,6 +420,7 @@ def test_lifecycle_command_arguments_shell_after(cmd, run_method, mocker):
                 build_for=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 http_proxy=None,
                 https_proxy=None,
             )
@@ -441,6 +450,7 @@ def test_lifecycle_command_arguments_http_proxy(cmd, run_method, mocker):
                 destructive_mode=False,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 enable_manifest=False,
                 http_proxy="test-http",
                 https_proxy=None,
@@ -476,6 +486,7 @@ def test_lifecycle_command_arguments_https_proxy(cmd, run_method, mocker):
                 debug=False,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 enable_manifest=False,
                 http_proxy=None,
                 https_proxy="test-https",
@@ -514,6 +525,7 @@ def test_lifecycle_command_pack(mocker):
                 build_for=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 http_proxy=None,
                 https_proxy=None,
             )
@@ -544,6 +556,7 @@ def test_lifecycle_command_pack_destructive_mode(mocker):
                 build_for=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 http_proxy=None,
                 https_proxy=None,
             )
@@ -574,6 +587,7 @@ def test_lifecycle_command_pack_use_lxd(mocker):
                 build_for=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 http_proxy=None,
                 https_proxy=None,
             )
@@ -604,6 +618,7 @@ def test_lifecycle_command_pack_enable_manifest(mocker):
                 build_for=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 http_proxy=None,
                 https_proxy=None,
             )
@@ -635,6 +650,7 @@ def test_lifecycle_command_pack_env_enable_manifest(mocker):
                 build_for=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 http_proxy=None,
                 https_proxy=None,
             )
@@ -665,6 +681,7 @@ def test_lifecycle_command_pack_manifest_image_information(mocker):
                 build_for=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 http_proxy=None,
                 https_proxy=None,
             )
@@ -690,6 +707,7 @@ def test_lifecycle_command_pack_env_manifest_image_information(mocker):
                 directory=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 enable_manifest=False,
                 http_proxy=None,
                 https_proxy=None,
@@ -720,6 +738,7 @@ def test_lifecycle_command_pack_bind_ssh(mocker):
                 directory=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 enable_manifest=False,
                 http_proxy=None,
                 https_proxy=None,
@@ -757,6 +776,7 @@ def test_lifecycle_command_pack_ua_token(mocker):
                 directory=None,
                 enable_experimental_ua_services=True,
                 enable_experimental_plugins=False,
+                pro=None,
                 enable_manifest=False,
                 http_proxy=None,
                 https_proxy=None,
@@ -788,6 +808,7 @@ def test_lifecycle_command_pack_env_ua_token(mocker):
                 directory=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 enable_manifest=False,
                 http_proxy=None,
                 https_proxy=None,
@@ -823,6 +844,7 @@ def test_lifecycle_command_pack_build_for(mocker):
                 build_for="armhf",
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 http_proxy=None,
                 https_proxy=None,
             )
@@ -854,6 +876,7 @@ def test_lifecycle_command_pack_env_build_for(mocker):
                 build_for="armhf",
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 http_proxy=None,
                 https_proxy=None,
             )
@@ -884,6 +907,7 @@ def test_lifecycle_command_pack_debug(mocker):
                 build_for=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 http_proxy=None,
                 https_proxy=None,
             )
@@ -906,6 +930,7 @@ def test_lifecycle_command_pack_output(mocker, option):
                 directory=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 enable_manifest=False,
                 http_proxy=None,
                 https_proxy=None,
@@ -932,6 +957,7 @@ def test_lifecycle_command_pack_directory(mocker):
                 directory="name",
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 enable_manifest=False,
                 http_proxy=None,
                 https_proxy=None,
@@ -958,6 +984,7 @@ def test_lifecycle_command_pack_http_proxy(mocker):
                 directory=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 enable_manifest=False,
                 http_proxy="test-http",
                 https_proxy=None,
@@ -984,6 +1011,7 @@ def test_lifecycle_command_pack_https_proxy(mocker):
                 directory=None,
                 enable_experimental_ua_services=False,
                 enable_experimental_plugins=False,
+                pro=None,
                 enable_manifest=False,
                 http_proxy=None,
                 https_proxy="test-https",

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -20,6 +20,7 @@ from unittest.mock import call
 
 import pytest
 
+import snapcraft.cli
 import snapcraft.commands.core22.lifecycle as core22_lifecycle
 import snapcraft.errors
 from snapcraft.application import APP_METADATA
@@ -96,6 +97,36 @@ def test_snap_command_error(mocker):
 
     with pytest.raises(snapcraft.errors.RemovedCommand, match=expected):
         cmd.run(argparse.Namespace(directory=None, output=None, compression=None))
+
+
+@pytest.mark.parametrize(
+    ("cmd_class", "parsed_args"),
+    [
+        *(
+            (cmd, argparse.Namespace(pro="esm-infra", directory=None))
+            for cmd in snapcraft.cli.CORE22_LIFECYCLE_COMMAND_GROUP.commands
+            if not cmd.hidden
+        ),
+        pytest.param(
+            core22_lifecycle.PackCommand,
+            argparse.Namespace(pro="esm-infra", directory="."),
+            id="PackCommand-with-directory",
+        ),
+    ],
+)
+def test_core22_lifecycle_pro_not_supported(cmd_class, parsed_args, mocker):
+    """--pro is not supported for core22 snaps."""
+    mocker.patch("snapcraft.parts.lifecycle.run")
+    mocker.patch("snapcraft.pack.pack_snap")
+    cmd = cmd_class(None)
+    expected = re.escape("'--pro' is not supported for core22.")
+
+    with pytest.raises(snapcraft.errors.SnapcraftError, match=expected) as raised:
+        cmd.run(parsed_args)
+
+    assert raised.value.resolution == (
+        "Use the 'ua-services' key in the project file instead."
+    )
 
 
 @pytest.mark.usefixtures("emitter")


### PR DESCRIPTION
Errors when using `--pro` for core22 snaps.

(CRAFT-5226)

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
