### PR TITLE
feat: add `dotnet11` extension

### DIFF
--- a/docs/reference/extensions/dotnet-extensions.rst
+++ b/docs/reference/extensions/dotnet-extensions.rst
@@ -10,6 +10,7 @@ version your application targets. The available extensions are:
 * ``dotnet8``: For applications targeting .NET 8 (``net8.0``)
 * ``dotnet9``: For applications targeting .NET 9 (``net9.0``)
 * ``dotnet10``: For applications targeting .NET 10 (``net10.0``)
+* ``dotnet11``: For applications targeting .NET 11 (``net11.0``)
 
 The .NET extensions are compatible with the core24 base.
 

--- a/snapcraft/extensions/dotnet11.py
+++ b/snapcraft/extensions/dotnet11.py
@@ -1,0 +1,42 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing_extensions import override
+
+from .dotnet_base import DotnetExtensionBase
+
+
+class Dotnet11Extension(DotnetExtensionBase):
+    """
+    An extension that eases the creation of snaps that integrate with
+    the .NET 11 content snaps.
+    """
+
+    @property
+    @override
+    def runtime_content_snap_name(self) -> str:
+        return "dotnet-runtime-110"
+
+    @property
+    @override
+    def versioned_plugin_name(self) -> str:
+        return "dotnet11"
+
+    @staticmethod
+    @override
+    def is_experimental(base: str | None) -> bool:
+        # The .NET 11 extension is considered experimental because it is a preview version of the .NET runtime.
+        return True

--- a/tests/spread/extensions/dotnet/task.yaml
+++ b/tests/spread/extensions/dotnet/task.yaml
@@ -8,15 +8,19 @@ environment:
   SNAP_DIR/dotnet8: ../snaps/dotnet8-hello
   SNAP_DIR/dotnet9: ../snaps/dotnet9-hello
   SNAP_DIR/dotnet10: ../snaps/dotnet10-hello
+  SNAP_DIR/dotnet11: ../snaps/dotnet11-hello
   SNAP/dotnet8: dotnet8-hello
   SNAP/dotnet9: dotnet9-hello
   SNAP/dotnet10: dotnet10-hello
+  SNAP/dotnet11: dotnet11-hello
   DOTNET_CONTENT_SNAP/dotnet8: dotnet-runtime-80
   DOTNET_CONTENT_SNAP/dotnet9: dotnet-runtime-90
   DOTNET_CONTENT_SNAP/dotnet10: dotnet-runtime-100
+  DOTNET_CONTENT_SNAP/dotnet11: dotnet-runtime-110
   DOTNET_RUNTIME_PLUG/dotnet8: dotnet8-runtime
   DOTNET_RUNTIME_PLUG/dotnet9: dotnet9-runtime
   DOTNET_RUNTIME_PLUG/dotnet10: dotnet10-runtime
+  DOTNET_RUNTIME_PLUG/dotnet11: dotnet11-runtime
 
 restore: |
 

--- a/tests/spread/extensions/snaps/dotnet11-hello/Program.cs
+++ b/tests/spread/extensions/snaps/dotnet11-hello/Program.cs
@@ -1,0 +1,2 @@
+// See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, .NET 11!");

--- a/tests/spread/extensions/snaps/dotnet11-hello/dotnet11-hello.csproj
+++ b/tests/spread/extensions/snaps/dotnet11-hello/dotnet11-hello.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net11.0</TargetFramework>
+    <RootNamespace>dotnet11_hello</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/tests/spread/extensions/snaps/dotnet11-hello/snap/snapcraft.yaml
+++ b/tests/spread/extensions/snaps/dotnet11-hello/snap/snapcraft.yaml
@@ -1,0 +1,21 @@
+name: dotnet11-hello
+base: core24
+version: '1.0'
+summary: A simple hello world snap using the dotnet11 extension
+description: |
+  This is a simple hello world snap using the dotnet11 extension.
+
+grade: stable
+confinement: strict
+
+parts:
+  hello:
+    plugin: dotnet
+    source: .
+    dotnet-version: '11.0'
+    dotnet-configuration: Release
+
+apps:
+  hello:
+    command: dotnet11-hello
+    extensions: [ dotnet11 ]

--- a/tests/unit/extensions/test_dotnet11.py
+++ b/tests/unit/extensions/test_dotnet11.py
@@ -1,0 +1,111 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from textwrap import dedent
+
+import pytest
+
+from snapcraft.extensions.dotnet11 import Dotnet11Extension
+from snapcraft.extensions.extension import get_extensions_data_dir
+
+_DOTNET_RUNTIME_PLUG_NAME = "dotnet11-runtime"
+_DOTNET_RUNTIME_CONTENT_SNAP_NAME = "dotnet-runtime-110"
+_VERSIONED_PLUGIN_NAME = "dotnet11"
+
+############
+# Fixtures #
+############
+
+
+@pytest.fixture
+def dotnet_extension():
+    return Dotnet11Extension(
+        yaml_data={"name": "test", "base": "core24", "parts": {}},
+        arch="amd64",
+        target_arch="amd64",
+    )
+
+
+##################
+# .NET Extension #
+##################
+
+
+def test_get_supported_bases(dotnet_extension):
+    assert dotnet_extension.get_supported_bases() == ("core24",)
+
+
+def test_get_supported_confinement(dotnet_extension):
+    assert dotnet_extension.get_supported_confinement() == (
+        "strict",
+        "devmode",
+    )
+
+
+def test_is_experimental():
+    assert Dotnet11Extension.is_experimental(base="core24") is True
+
+
+def test_get_root_snippet(dotnet_extension):
+    assert dotnet_extension.get_root_snippet() == {
+        "plugs": {
+            _DOTNET_RUNTIME_PLUG_NAME: {
+                "interface": "content",
+                "default-provider": _DOTNET_RUNTIME_CONTENT_SNAP_NAME,
+                "content": _DOTNET_RUNTIME_CONTENT_SNAP_NAME,
+                "target": f"$SNAP/opt/{_VERSIONED_PLUGIN_NAME}",
+            }
+        }
+    }
+
+
+def test_get_app_snippet(dotnet_extension):
+    assert dotnet_extension.get_app_snippet(app_name="test") == {
+        "command-chain": ["bin/command-chain/launcher.sh"],
+        "environment": {
+            "DOTNET_EXT_CONTENT_SNAP": _DOTNET_RUNTIME_CONTENT_SNAP_NAME,
+            "DOTNET_EXT_SNAP_NAME": "test",
+            "DOTNET_EXT_PLUG_NAME": _DOTNET_RUNTIME_PLUG_NAME,
+            "DOTNET_ROOT": f"$SNAP/opt/{_VERSIONED_PLUGIN_NAME}/dotnet",
+        },
+        "plugs": [_DOTNET_RUNTIME_PLUG_NAME],
+    }
+
+
+def test_get_parts_snippet(dotnet_extension):
+    assert dotnet_extension.get_parts_snippet() == {
+        f"{_VERSIONED_PLUGIN_NAME}/launcher": {
+            "plugin": "dump",
+            "source": f"{get_extensions_data_dir()}/dotnet",
+            "override-build": dedent("""
+                mkdir -p $CRAFT_PART_INSTALL/bin/command-chain
+                cp launcher.sh $CRAFT_PART_INSTALL/bin/command-chain
+            """),
+            "stage": [
+                "bin/command-chain/launcher.sh",
+            ],
+        },
+        f"{_VERSIONED_PLUGIN_NAME}/prereqs": {
+            "plugin": "nil",
+            "stage-packages": [
+                "libicu74",
+                "libunwind8",
+                "libssl3t64",
+                "liblttng-ust1t64",
+                "libbrotli1",
+            ],
+        },
+    }


### PR DESCRIPTION
This PR adds the `dotnet11` extension.

Since .NET 11 is currently in preview, with final release expected in November 2026, the extension is marked as **experimental**. The plan is to mark it as stable when .NET 11 GA is available in November.

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [X] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
