### PR TITLE
feat: resolve icon names from the hicolor theme

### DIFF
--- a/snapcraft/meta/appstream.py
+++ b/snapcraft/meta/appstream.py
@@ -259,7 +259,7 @@ def _extract_icon(
         return icon
 
     if icon_node_type == "stock" and icon is not None:
-        return _get_icon_from_theme(workdir, "hicolor", icon)
+        return get_icon_from_theme(workdir, "hicolor", icon)
 
     # If an icon path is specified and the icon file exists, we'll use that, otherwise
     # we'll fall back to what's listed in the desktop file.
@@ -287,14 +287,14 @@ def _get_icon_from_desktop_file(
         icon_path = (
             icon
             if os.path.isabs(icon)
-            else _get_icon_from_theme(workdir, "hicolor", icon)
+            else get_icon_from_theme(workdir, "hicolor", icon)
         )
         return icon_path
 
     return None
 
 
-def _get_icon_from_theme(workdir: str, theme: str, icon: str) -> str | None:
+def get_icon_from_theme(workdir: str, theme: str, icon: str) -> str | None:
     # Icon themes can carry icons in different pre-rendered sizes or scalable. Scalable
     # implementation is optional, so we'll try the largest pixmap and then scalable if
     # no other sizes are available.

--- a/snapcraft/parts/desktop_file.py
+++ b/snapcraft/parts/desktop_file.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING
 from craft_cli import emit
 
 from snapcraft import errors
+from snapcraft.meta.appstream import _get_icon_from_theme
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -93,6 +94,15 @@ class DesktopFile:
 
             # Strip any leading ${SNAP}.
             icon = icon[8:] if icon.startswith("${SNAP}") else icon
+
+            # If icon is just a name (no path separator), try to resolve it from the hicolor icon theme.
+            if "/" not in icon:
+                if (
+                    icon_path := _get_icon_from_theme(
+                        os.fspath(self._prime_dir), "hicolor", icon
+                    )
+                ) is not None:
+                    self._parser[section]["Icon"] = os.path.join("${SNAP}", icon_path)
 
             # With everything stripped, check to see if the icon is there.
             # if it is, add "${SNAP}" back and set the icon

--- a/snapcraft/parts/desktop_file.py
+++ b/snapcraft/parts/desktop_file.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING
 from craft_cli import emit
 
 from snapcraft import errors
-from snapcraft.meta.appstream import _get_icon_from_theme
+from snapcraft.meta.appstream import get_icon_from_theme
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -98,7 +98,7 @@ class DesktopFile:
             # If icon is just a name (no path separator), try to resolve it from the hicolor icon theme.
             if "/" not in icon:
                 if (
-                    icon_path := _get_icon_from_theme(
+                    icon_path := get_icon_from_theme(
                         os.fspath(self._prime_dir), "hicolor", icon
                     )
                 ) is not None:

--- a/tests/unit/parts/test_desktop_file.py
+++ b/tests/unit/parts/test_desktop_file.py
@@ -178,6 +178,43 @@ class TestDesktopIcon:
                 """
             )
 
+    def test_generate_desktop_file_icon_from_theme(self, new_dir):
+        """Icon name without path separator is resolved from the hicolor icon theme."""
+        snap_name = app_name = "foo"
+        icon = "io.snapcraft.test-icon"
+
+        theme_icon_dir = (
+            new_dir / "usr" / "share" / "icons" / "hicolor" / "48x48" / "apps"
+        )
+        theme_icon_dir.mkdir(parents=True)
+        (theme_icon_dir / f"{icon}.png").touch()
+
+        desktop_file_path = new_dir / "app.desktop"
+        with desktop_file_path.open("w") as desktop_file:
+            print("[Desktop Entry]", file=desktop_file)
+            print("Exec=in-snap-exe", file=desktop_file)
+            print(f"Icon={icon}", file=desktop_file)
+
+        d = DesktopFile(
+            snap_name=snap_name,
+            app_name=app_name,
+            filename=desktop_file_path,
+            prime_dir=new_dir,
+        )
+        d.write(gui_dir=Path())
+
+        expected_desktop_file = new_dir / f"{app_name}.desktop"
+        assert expected_desktop_file.exists()
+        with expected_desktop_file.open() as desktop_file:
+            assert desktop_file.read() == dedent(
+                f"""\
+                [Desktop Entry]
+                Exec=foo
+                Icon=${{SNAP}}/usr/share/icons/hicolor/48x48/apps/{icon}.png
+
+                """
+            )
+
 
 def test_not_found(new_dir):
     with pytest.raises(errors.DesktopFileError):


### PR DESCRIPTION
Currently snapcraft ignores if an icon is provided as a name in the desktop file, snapcraft doesn't try to normalize the path. This patch fixes that by reusing the logic from appstream metadata.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [x] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [x] I've updated the relevant release notes.
