### PR TITLE
feat: error on ua-services for core24+

### DIFF
--- a/snapcraft/cli.py
+++ b/snapcraft/cli.py
@@ -52,11 +52,11 @@ CORE22_LIFECYCLE_COMMAND_GROUP = craft_cli.CommandGroup(
 CORE24_LIFECYCLE_COMMAND_GROUP = craft_cli.CommandGroup(
     "Lifecycle",
     [
-        craft_application.commands.lifecycle.CleanCommand,
-        craft_application.commands.lifecycle.PullCommand,
-        craft_application.commands.lifecycle.BuildCommand,
-        craft_application.commands.lifecycle.StageCommand,
-        craft_application.commands.lifecycle.PrimeCommand,
+        commands.CleanCommand,
+        commands.PullCommand,
+        commands.BuildCommand,
+        commands.StageCommand,
+        commands.PrimeCommand,
         craft_application.commands.lifecycle.TestCommand,
         commands.PackCommand,
         commands.SnapCommand,  # Hidden (legacy compatibility)

--- a/snapcraft/commands/__init__.py
+++ b/snapcraft/commands/__init__.py
@@ -35,7 +35,16 @@ from .keys import (
     StoreRegisterKeyCommand,
     StoreSignBuildCommand,
 )
-from .lifecycle import PackCommand, SnapCommand, TryCommand
+from .lifecycle import (
+    BuildCommand,
+    CleanCommand,
+    PackCommand,
+    PrimeCommand,
+    PullCommand,
+    SnapCommand,
+    StageCommand,
+    TryCommand,
+)
 from .lint import LintCommand
 from .manage import (
     StoreCloseCommand,
@@ -86,9 +95,14 @@ __all__ = [
     "ListExtensionsCommand",
     "ListPluginsCommand",
     "RemoteBuildCommand",
+    "BuildCommand",
+    "CleanCommand",
     "PackCommand",
     "PluginsCommand",
+    "PrimeCommand",
+    "PullCommand",
     "SnapCommand",
+    "StageCommand",
     "StoreCloseCommand",
     "StoreConfdbSchemasCommand",
     "StoreCreateKeyCommand",

--- a/snapcraft/commands/lifecycle.py
+++ b/snapcraft/commands/lifecycle.py
@@ -56,7 +56,7 @@ def _validate_ua_args(parsed_args: argparse.Namespace) -> None:
             "The Pro token attached to the host will be used instead."
         )
 
-    if parsed_args.ua_token:
+    if parsed_args.ua_token is not None:
         raise errors.SnapcraftError(
             "'--ua-token' is not supported for this base.",
             details="The Pro token attached to the host is used instead.",

--- a/snapcraft/commands/lifecycle.py
+++ b/snapcraft/commands/lifecycle.py
@@ -49,7 +49,11 @@ def _add_ua_args(parser: argparse.ArgumentParser) -> None:
 
 
 def _validate_ua_args(parsed_args: argparse.Namespace) -> None:
-    """Error if UA args or environment variables are used."""
+    """Validate if UA args or environment variables are used.
+
+    Using a UA command line argument is an error, but the UA environment variable
+    will only emit a warning.
+    """
     if os.environ.get("SNAPCRAFT_UA_TOKEN"):
         emit.warning(
             "Ignoring the 'SNAPCRAFT_UA_TOKEN' environment variable. "

--- a/snapcraft/commands/lifecycle.py
+++ b/snapcraft/commands/lifecycle.py
@@ -17,6 +17,7 @@
 """Snapcraft lifecycle commands."""
 
 import argparse
+import os
 import textwrap
 from typing import Any, cast
 
@@ -28,6 +29,135 @@ import snapcraft.errors
 import snapcraft.pack
 from snapcraft import errors
 from snapcraft.models.project import Project
+
+
+def _add_ua_args(parser: argparse.ArgumentParser) -> None:
+    """Add hidden UA args."""
+    parser.add_argument(
+        "--ua-token",
+        type=str,
+        metavar="ua-token",
+        default=None,
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--enable-experimental-ua-services",
+        action="store_true",
+        default=False,
+        help=argparse.SUPPRESS,
+    )
+
+
+def _validate_ua_args(parsed_args: argparse.Namespace) -> None:
+    """Error if UA args or environment variables are used."""
+    if os.environ.get("SNAPCRAFT_UA_TOKEN"):
+        emit.warning(
+            "Ignoring the 'SNAPCRAFT_UA_TOKEN' environment variable. "
+            "The Pro token attached to the host will be used instead."
+        )
+
+    if parsed_args.ua_token:
+        raise errors.SnapcraftError(
+            "'--ua-token' is not supported for this base.",
+            details="The Pro token attached to the host is used instead.",
+            resolution="Remove the '--ua-token' argument.",
+        )
+
+    if parsed_args.enable_experimental_ua_services:
+        raise errors.SnapcraftError(
+            "Pro support is stable for this base.",
+            resolution="Remove the '--enable-experimental-ua-services' argument.",
+        )
+
+
+class PullCommand(craft_application.commands.lifecycle.PullCommand):
+    """Snapcraft pull command."""
+
+    @override
+    def _fill_parser(self, parser: argparse.ArgumentParser) -> None:
+        super()._fill_parser(parser)
+        _add_ua_args(parser)
+
+    @override
+    def _run(
+        self,
+        parsed_args: argparse.Namespace,
+        step_name: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        _validate_ua_args(parsed_args)
+        super()._run(parsed_args, step_name=step_name, **kwargs)
+
+
+class BuildCommand(craft_application.commands.lifecycle.BuildCommand):
+    """Snapcraft build command."""
+
+    @override
+    def _fill_parser(self, parser: argparse.ArgumentParser) -> None:
+        super()._fill_parser(parser)
+        _add_ua_args(parser)
+
+    @override
+    def _run(
+        self,
+        parsed_args: argparse.Namespace,
+        step_name: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        _validate_ua_args(parsed_args)
+        super()._run(parsed_args, step_name=step_name, **kwargs)
+
+
+class StageCommand(craft_application.commands.lifecycle.StageCommand):
+    """Snapcraft stage command."""
+
+    @override
+    def _fill_parser(self, parser: argparse.ArgumentParser) -> None:
+        super()._fill_parser(parser)
+        _add_ua_args(parser)
+
+    @override
+    def _run(
+        self,
+        parsed_args: argparse.Namespace,
+        step_name: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        _validate_ua_args(parsed_args)
+        super()._run(parsed_args, step_name=step_name, **kwargs)
+
+
+class PrimeCommand(craft_application.commands.lifecycle.PrimeCommand):
+    """Snapcraft prime command."""
+
+    @override
+    def _fill_parser(self, parser: argparse.ArgumentParser) -> None:
+        super()._fill_parser(parser)
+        _add_ua_args(parser)
+
+    @override
+    def _run(
+        self,
+        parsed_args: argparse.Namespace,
+        step_name: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        _validate_ua_args(parsed_args)
+        super()._run(parsed_args, step_name=step_name, **kwargs)
+
+
+class CleanCommand(craft_application.commands.lifecycle.CleanCommand):
+    """Snapcraft clean command."""
+
+    @override
+    def _fill_parser(self, parser: argparse.ArgumentParser) -> None:
+        super()._fill_parser(parser)
+        _add_ua_args(parser)
+
+    @override
+    def _run(self, parsed_args: argparse.Namespace, **kwargs: Any) -> None:
+        _validate_ua_args(parsed_args)
+        super()._run(parsed_args, **kwargs)
 
 
 class PackCommand(craft_application.commands.lifecycle.PackCommand):
@@ -47,6 +177,7 @@ class PackCommand(craft_application.commands.lifecycle.PackCommand):
     def _fill_parser(self, parser: argparse.ArgumentParser) -> None:
         """Add arguments specific to the pack command."""
         super()._fill_parser(parser)
+        _add_ua_args(parser)
 
         parser.add_argument(
             "directory",
@@ -72,6 +203,7 @@ class PackCommand(craft_application.commands.lifecycle.PackCommand):
             )
             emit.message(f"Packed {snap_filename}")
         else:
+            _validate_ua_args(parsed_args)
             super()._run(parsed_args)
 
     @override

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -167,3 +167,97 @@ def test_core24_snap_error(fake_services, tmp_path):
 
     with pytest.raises(snapcraft.errors.RemovedCommand, match=expected):
         cmd.run(parsed_args)
+
+
+@pytest.mark.parametrize(
+    "cmd_class",
+    [
+        lifecycle.PullCommand,
+        lifecycle.BuildCommand,
+        lifecycle.StageCommand,
+        lifecycle.PrimeCommand,
+        lifecycle.CleanCommand,
+        lifecycle.PackCommand,
+    ],
+)
+def test_ua_token_error(cmd_class, fake_services):
+    """'--ua-token' is not supported for core24+ snaps."""
+    parsed_args = argparse.Namespace(
+        destructive_mode=False,
+        directory=None,
+        ua_token="my-token",
+        enable_experimental_ua_services=False,
+    )
+    cmd = cmd_class({"app": APP_METADATA, "services": fake_services})
+
+    with pytest.raises(snapcraft.errors.SnapcraftError) as raised:
+        cmd.run(parsed_args)
+
+    assert str(raised.value) == "'--ua-token' is not supported for this base."
+    assert raised.value.details == (
+        "The Pro token attached to the host is used instead."
+    )
+    assert raised.value.resolution == "Remove the '--ua-token' argument."
+
+
+@pytest.mark.parametrize(
+    "cmd_class",
+    [
+        lifecycle.PullCommand,
+        lifecycle.BuildCommand,
+        lifecycle.StageCommand,
+        lifecycle.PrimeCommand,
+        lifecycle.CleanCommand,
+        lifecycle.PackCommand,
+    ],
+)
+def test_enable_experimental_ua_services_error(cmd_class, fake_services):
+    """'--enable-experimental-ua-services' is not supported for core24+."""
+    parsed_args = argparse.Namespace(
+        destructive_mode=False,
+        directory=None,
+        ua_token=None,
+        enable_experimental_ua_services=True,
+    )
+    cmd = cmd_class({"app": APP_METADATA, "services": fake_services})
+
+    with pytest.raises(snapcraft.errors.SnapcraftError) as raised:
+        cmd.run(parsed_args)
+
+    assert str(raised.value) == "Pro support is stable for this base."
+    assert raised.value.resolution == (
+        "Remove the '--enable-experimental-ua-services' argument."
+    )
+
+
+@pytest.mark.parametrize(
+    "cmd_class",
+    [
+        lifecycle.PullCommand,
+        lifecycle.BuildCommand,
+        lifecycle.StageCommand,
+        lifecycle.PrimeCommand,
+        lifecycle.CleanCommand,
+        lifecycle.PackCommand,
+    ],
+)
+def test_ua_token_env_warning(
+    cmd_class, fake_services, emitter, monkeypatch, mocker
+):
+    """Warn that 'SNAPCRAFT_UA_TOKEN' is ignored for core24+ snaps."""
+    monkeypatch.setenv("SNAPCRAFT_UA_TOKEN", "my-token")
+    mocker.patch.object(cmd_class.__bases__[0], "_run")
+    parsed_args = argparse.Namespace(
+        destructive_mode=False,
+        directory=None,
+        ua_token=None,
+        enable_experimental_ua_services=False,
+    )
+    cmd = cmd_class({"app": APP_METADATA, "services": fake_services})
+
+    cmd.run(parsed_args)
+
+    emitter.assert_warning(
+        "Ignoring the 'SNAPCRAFT_UA_TOKEN' environment variable. "
+        "The Pro token attached to the host will be used instead."
+    )

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -241,9 +241,7 @@ def test_enable_experimental_ua_services_error(cmd_class, fake_services):
         lifecycle.PackCommand,
     ],
 )
-def test_ua_token_env_warning(
-    cmd_class, fake_services, emitter, monkeypatch, mocker
-):
+def test_ua_token_env_warning(cmd_class, fake_services, emitter, monkeypatch, mocker):
     """Warn that 'SNAPCRAFT_UA_TOKEN' is ignored for core24+ snaps."""
     monkeypatch.setenv("SNAPCRAFT_UA_TOKEN", "my-token")
     mocker.patch.object(cmd_class.__bases__[0], "_run")


### PR DESCRIPTION
Core24 and higher snaps now
- error on `--ua-services`,
- error on `--enable-experimental-ua-services`, and
- warn on `SNAPCRAFT_UA_TOKEN`.

(CRAFT-5246)

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
