### PR TITLE
docs: update supported bases

### DIFF
--- a/docs/reference/bases.rst
+++ b/docs/reference/bases.rst
@@ -29,10 +29,10 @@ There are six supported base snaps:
      - 9.x
    * - `core24`_
      - built from `Ubuntu 24.04 LTS`_
-     - 8.x
+     - 9.x
    * - `core22`_
      - built from `Ubuntu 22.04 LTS`_
-     - 8.x
+     - 9.x
    * - `core20`_
      - built from `Ubuntu 20.04 LTS`_
      - 8.x


### PR DESCRIPTION
Updates the docs to reflect that Snapcraft 9 is the preferred version for core22, core24, and core26.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [x] I've added or updated any relevant documentation.
- [x] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [x] I've updated the relevant release notes.
