### PR TITLE
docs: configure 8.15 docs for ubuntu.com proxy

### DIFF
--- a/docs/_static/js/overwrite-links.js
+++ b/docs/_static/js/overwrite-links.js
@@ -1,0 +1,38 @@
+// Replace oldDomain with newDomain
+const oldDomain = 'canonical-snapcraft-proxy.readthedocs-hosted.com';
+const newDomain = 'ubuntu.com/docs/snapcraft';
+
+function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function overwriteMatchingAnchorUrls(container) {
+    if (!container) return;
+
+    const anchors = container.querySelectorAll('a[href], link[href]');
+    const oldDomainRegex = new RegExp(escapeRegExp(oldDomain), 'g');
+
+    anchors.forEach(anchor => {
+        anchor.href = anchor.href.replace(oldDomainRegex, newDomain);
+    });
+}
+
+overwriteMatchingAnchorUrls(document.querySelector('header'));
+
+// Use a MutationObserver to wait for the RTD flyout element to appear in the DOM
+const observer = new MutationObserver(function(mutations, obs) {
+
+    const rtdFlyout = document.querySelector('readthedocs-flyout');
+    if (!rtdFlyout) return;
+
+    obs.disconnect();
+
+    rtdFlyout.addEventListener('click', function() {
+        const shadowRoot = rtdFlyout.shadowRoot;
+        if (!shadowRoot) return;
+
+        overwriteMatchingAnchorUrls(shadowRoot);
+    });
+});
+
+observer.observe(document.body, { childList: true, subtree: true });

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,8 +33,7 @@ if os.environ.get("READTHEDOCS_VERSION_TYPE", "external") == "external":  # PR o
     major, minor, *_ = snapcraft.__version__.split(".")
     release = f"{major}.{minor}"
 else:  # Branch build
-    rtd_version = os.environ.get("READTHEDOCS_VERSION", "latest")
-    release = "dev" if rtd_version == "latest" else rtd_version
+    release = os.environ.get("READTHEDOCS_VERSION", "latest")
 
 copyright = "2015-%s, %s" % (datetime.date.today().year, author)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,26 +26,27 @@ import snapcraft
 
 project = "Snapcraft"
 author = "Canonical Group Ltd"
-# The full version, including alpha/beta/rc tags
-release = snapcraft.__version__
-if ".post" in release:
-    release = "dev"
-else:
-    major, minor, *_ = release.split(".")
+
+# Version string in sidebar
+if os.environ.get("READTHEDOCS_VERSION_TYPE", "external") == "external":  # PR or local build
+    # Because of Autotools, we can safely assume the version starts with `n.n`
+    major, minor, *_ = snapcraft.__version__.split(".")
     release = f"{major}.{minor}"
+else:  # Branch build
+    rtd_version = os.environ.get("READTHEDOCS_VERSION", "latest")
+    release = "dev" if rtd_version == "latest" else rtd_version
 
 copyright = "2015-%s, %s" % (datetime.date.today().year, author)
 
 # region Configuration for canonical-sphinx
-ogp_site_url = "https://documentation.ubuntu.com/snapcraft"
+ogp_site_url = "https://ubuntu.com/docs/snapcraft"
 ogp_site_name = project
 
 # Project slug; see https://meta.discourse.org/t/what-is-category-slug/87897
 #
 # TODO: If your documentation is hosted on https://docs.ubuntu.com/,
 #       uncomment and update as needed.
-
-slug = "snapcraft"
+slug = "docs/snapcraft"
 
 html_context = {
     "product_page": "snapcraft.io",
@@ -76,6 +77,7 @@ html_js_files = [
     "js/bundle.js",
     "https://cdn.jsdelivr.net/npm/d3@7.9.0/dist/d3.min.js",
     "js/support-chart.js",
+    "js/overwrite-links.js",
 ]
 
 extensions = [
@@ -138,16 +140,16 @@ exclude_patterns = [
 rediraffe_redirects = "redirects.txt"
 
 # Sitemap configuration: https://sphinx-sitemap.readthedocs.io/
-html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
+html_baseurl = f"{ogp_site_url}/{release}/"
 
 # Builds URLs as {html_baseurl}/<page-location>
 sitemap_url_scheme = "{link}"
 
 # Exclude generated pages from the sitemap:
 sitemap_excludes = [
-    '404/',
-    'genindex/',
-    'search/',
+    "404/",
+    "genindex/",
+    "search/",
 ]
 
 # endregion


### PR DESCRIPTION
Configure the docs for migration to the ubuntu.com domain

---

- [X] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [X] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
