### PR TITLE
ci(scan): fix osv scanner on docs

### DIFF
--- a/.github/workflows/policy.yaml
+++ b/.github/workflows/policy.yaml
@@ -17,6 +17,7 @@ jobs:
       osv-extra-args: "--config osv-scanner.toml"
       osv-exclude-paths: |
         docs
+        tests/spread
       uv-export-no-groups: |
         docs
         docs-starter-pack

--- a/.github/workflows/policy.yaml
+++ b/.github/workflows/policy.yaml
@@ -14,10 +14,9 @@ jobs:
     name: Security scan
     uses: canonical/starflow/.github/workflows/scan-python.yaml@main
     with:
-      # 1. requirements-noble.txt can't build on jammy
-      # 2. Ignore requirements files in spread tests, as some of these intentionally
-      #    contain vulnerable versions.
-      # 3. Docs contain requirements.txt files that don't specify versions.
-      requirements-find-args: '! -name requirements-noble.txt ! -path "./tests/spread*" ! -path "./docs/**"'
-      trivy-extra-args: "--severity HIGH,CRITICAL --ignore-unfixed --skip-dirs tests/spread/"
-      osv-extra-args: "--config source/osv-scanner.toml"
+      osv-extra-args: "--config osv-scanner.toml"
+      osv-exclude-paths: |
+        docs
+      uv-export-no-groups: |
+        docs
+        docs-starter-pack


### PR DESCRIPTION
Pulls in the changes from https://github.com/canonical/starbase/pull/573

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
