### PR TITLE
feat: implement metadata mediation for snap.yaml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ dynamic = ["version"]
 dependencies = [
     "catkin-pkg==1.1.0; sys_platform == 'linux'",
     "click>=8.2",
-    "craft-application[remote]>=6.4.0",
+    "craft-application[remote]>=7.1.0",
     "craft-archives>=2.2.0",
     "craft-cli>=3.4.0",
     "craft-grammar>=2.3.0",

--- a/snapcraft/commands/lifecycle.py
+++ b/snapcraft/commands/lifecycle.py
@@ -85,7 +85,7 @@ class PackCommand(craft_application.commands.lifecycle.PackCommand):
         return True
 
     @override
-    def run_managed(self, parsed_args: argparse.Namespace) -> bool:
+    def _use_provider(self, parsed_args: argparse.Namespace) -> bool:
         """Return whether the command should run in managed mode or not.
 
         Packing a directory always runs locally.
@@ -94,7 +94,7 @@ class PackCommand(craft_application.commands.lifecycle.PackCommand):
             emit.debug("Not running managed mode because a directory was provided.")
             return False
 
-        return super().run_managed(parsed_args)
+        return super()._use_provider(parsed_args)
 
 
 class TryCommand(PackCommand):
@@ -110,7 +110,7 @@ class TryCommand(PackCommand):
     )
 
     @override
-    def run_managed(self, parsed_args: argparse.Namespace) -> bool:
+    def _use_provider(self, parsed_args: argparse.Namespace) -> bool:
         """Overridden to return false, such that the command fails early."""
         return False
 

--- a/snapcraft/meta/snap_yaml.py
+++ b/snapcraft/meta/snap_yaml.py
@@ -551,6 +551,8 @@ def _populate_environment(
             "PATH": "$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH",
         }
 
+    environment = environment.copy()
+
     # if LD_LIBRARY_PATH is not defined, use default value when not classic
     if "LD_LIBRARY_PATH" not in environment and confinement != "classic":
         environment["LD_LIBRARY_PATH"] = get_ld_library_paths(prime_dir, arch_triplet)

--- a/snapcraft/services/package.py
+++ b/snapcraft/services/package.py
@@ -306,6 +306,18 @@ class Package(PackageService):
             return None
         return self._package_output_dir
 
+    @override
+    def _prime_dir_for(self, partition_name: str | None) -> pathlib.Path:
+        """Return the prime directory for the requested artifact.
+
+        Component artifacts are keyed by component name in Snapcraft, while
+        craft-application's default implementation expects full partition names.
+        """
+        if partition_name in (None, "default"):
+            return self._services.lifecycle.prime_dir
+
+        return cast(Lifecycle, self._services.lifecycle).get_prime_dir(partition_name)
+
     def _pack_snap(
         self, prime_dir: pathlib.Path, output_path: pathlib.Path
     ) -> pathlib.Path:

--- a/snapcraft/services/package.py
+++ b/snapcraft/services/package.py
@@ -23,7 +23,8 @@ import pathlib
 import shutil
 from typing import Literal, cast
 
-from craft_application import PackageService
+from craft_application import PackageService, util
+from craft_application.services.package import package_file
 from craft_application.util import strtobool
 from craft_cli import emit
 from typing_extensions import override
@@ -43,6 +44,15 @@ from snapcraft.utils import process_version
 class Package(PackageService):
     """Package service subclass for Snapcraft."""
 
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._package_output_dir: str | None = None
+
+    @package_file("meta/snap.yaml", partition_re="default")
+    def _get_snap_yaml(self, partition: str | None = None) -> str:  # noqa: ARG002
+        """Generate the mediated snap metadata file."""
+        return util.dump_yaml(self.metadata.marshal())
+
     @override
     def setup(self) -> None:
         """Application-specific service setup."""
@@ -60,6 +70,12 @@ class Package(PackageService):
             self._build_for = build_plan[0].build_for
             self._platform = build_plan[0].platform
 
+    @override
+    def set_output_dir(self, path: pathlib.Path | str | None) -> None:
+        """Follow the requested output dir so artifact paths match legacy packing."""
+        self._package_output_dir = None if path is None else str(path)
+        super().set_output_dir(pathlib.Path() if path is None else pathlib.Path(path))
+
     @property
     def _project(self) -> models.Project:
         """Get the project.
@@ -70,7 +86,7 @@ class Package(PackageService):
         return cast(models.Project, self._project_service.get())
 
     @override
-    def _extra_project_updates(self) -> None:
+    def _extra_project_updates(self) -> bool:
         # Update the project from parse-info data.
         project_info = self._services.lifecycle.project_info
         extracted_metadata = extract.extract_lifecycle_metadata(
@@ -91,6 +107,8 @@ class Package(PackageService):
         if self._project.get_effective_base() not in ("core22", "core24"):
             self._precreate_layout_targets()
             self._precreate_plug_targets()
+
+        return True
 
     def _precreate_layout_targets(self) -> None:
         """Create layout targets ahead of time for snapd to avoid ENOENT errors."""
@@ -208,7 +226,8 @@ class Package(PackageService):
         exist (no-op).
 
         :param path: String path to investigate
-        :returns: A Path object that needs to be created, or None if nothing needs to be done."""
+        :returns: A Path object that needs to be created, or None if nothing needs to be done.
+        """
         # Make explicit references to the snap root ($SNAP) relative
         if path.startswith("$SNAP/"):
             path = path.removeprefix("$SNAP/")
@@ -269,6 +288,91 @@ class Package(PackageService):
 
         return component_map
 
+    def _component_artifact_path(self, component_name: str) -> pathlib.Path:
+        """Return the expected output path for a component artifact."""
+        if self._project.components is None:
+            raise ValueError("Project does not define components.")
+
+        component = self._project.components[component_name]
+        filename = f"{self._project.name}+{component_name}"
+        if component.version is not None:
+            filename += f"_{component.version}"
+        filename += ".comp"
+        return pathlib.Path(pack._get_directory(self._get_output_dir())) / filename
+
+    def _get_output_dir(self) -> str | None:
+        """Return the requested pack output in the legacy pack_snap format."""
+        if self._package_output_dir is None:
+            return None
+        return self._package_output_dir
+
+    def _pack_snap(
+        self, prime_dir: pathlib.Path, output_path: pathlib.Path
+    ) -> pathlib.Path:
+        """Pack the main snap artifact."""
+        return pathlib.Path(
+            pack.pack_snap(
+                prime_dir,
+                output=str(output_path),
+                compression=self._project.compression,
+                name=self._project.name,
+                version=process_version(self._project.version),
+                target=self._platform,
+            )
+        )
+
+    def _run_lint_checks(self, prime_dir: pathlib.Path) -> None:
+        """Run configured linters and stop packaging on errors."""
+        issues = linters.run_linters(prime_dir, lint=self._project.lint)
+        status = linters.report(issues, intermediate=True)
+
+        if status in (LinterStatus.ERRORS, LinterStatus.FATAL):
+            raise errors.LinterError("Linter errors found", exit_code=status)
+
+    @override
+    def get_artifacts(self) -> dict[str | None, pathlib.Path]:
+        """Return the declared output artifacts for mediated packaging."""
+        output_dir = self._get_output_dir()
+        main_artifact = pathlib.Path(pack._get_directory(output_dir)) / cast(
+            str,
+            pack._get_filename(
+                output_dir,
+                self._project.name,
+                process_version(self._project.version),
+                self._platform,
+            ),
+        )
+        artifacts: dict[str | None, pathlib.Path] = {None: main_artifact}
+        for component_name in self._project.get_component_names():
+            artifacts[component_name] = self._component_artifact_path(component_name)
+        return artifacts
+
+    @override
+    def _pack(self, *, name: str | None = None, path: pathlib.Path) -> None:
+        """Pack mediated artifacts."""
+        self._run_lint_checks(self._services.lifecycle.prime_dir)
+
+        if name in (None, "default"):
+            prime_dir = self._services.lifecycle.prime_dir
+            self._pack_snap(prime_dir=prime_dir, output_path=path)
+            return
+
+        if name not in self._project.get_component_names():
+            raise ValueError(f"Unexpected artifact name: {name!r}")
+
+        component_prime_dir = cast(Lifecycle, self._services.lifecycle).get_prime_dir(
+            name
+        )
+        compression = self._project.compression
+        if self._project.components and self._project.components[name].compression:
+            compression = self._project.components[name].compression
+
+        pack.pack_component(
+            component_prime_dir,
+            compression=compression,
+            output_dir=path.parent,
+        )
+
     @override
     def pack(self, prime_dir: pathlib.Path, dest: pathlib.Path) -> list[pathlib.Path]:
         """Create one or more packages as appropriate.
@@ -277,23 +381,9 @@ class Package(PackageService):
         :param dest: Directory into which to write the package(s).
         :returns: A list of paths to created packages.
         """
-        issues = linters.run_linters(prime_dir, lint=self._project.lint)
-        status = linters.report(issues, intermediate=True)
+        self._run_lint_checks(prime_dir)
 
-        # In case of linter errors, stop execution and return the error code.
-        if status in (LinterStatus.ERRORS, LinterStatus.FATAL):
-            raise errors.LinterError("Linter errors found", exit_code=status)
-
-        snap_file = pathlib.Path(
-            pack.pack_snap(
-                prime_dir,
-                output=str(dest),
-                compression=self._project.compression,
-                name=self._project.name,
-                version=process_version(self._project.version),
-                target=self._platform,
-            )
-        )
+        snap_file = self._pack_snap(prime_dir=prime_dir, output_path=dest)
         component_map = self._pack_components(dest)
         self._resource_map = component_map
 
@@ -324,7 +414,9 @@ class Package(PackageService):
         """
         meta_dir = path / "meta"
         meta_dir.mkdir(parents=True, exist_ok=True)
-        self.metadata.to_yaml_file(meta_dir / "snap.yaml")
+        meta_dir.joinpath("snap.yaml").write_text(
+            self._get_snap_yaml(), encoding="utf-8"
+        )
 
         enable_manifest = strtobool(os.getenv("SNAPCRAFT_BUILD_INFO", "n"))
 

--- a/tests/unit/cli/test_version.py
+++ b/tests/unit/cli/test_version.py
@@ -30,10 +30,7 @@ def test_version_command(mocker):
         "craft_application.commands.other.VersionCommand.run"
     )
     app.run()
-    assert mock_version_cmd.mock_calls == [
-        call(argparse.Namespace()),
-        call().__bool__(),
-    ]
+    assert mock_version_cmd.mock_calls == [call(argparse.Namespace())]
 
 
 def test_version_argument(mocker, emitter):

--- a/tests/unit/meta/test_snap_yaml.py
+++ b/tests/unit/meta/test_snap_yaml.py
@@ -815,6 +815,26 @@ def test_project_environment_ld_library_path_null(simple_project, new_dir):
     )
 
 
+def test_project_environment_all_null_does_not_mutate_project(simple_project, new_dir):
+    environment = {"LD_LIBRARY_PATH": None, "PATH": None}
+    project = simple_project(environment=environment)
+
+    first_metadata = snap_yaml.get_metadata_from_project(
+        project,
+        Path(new_dir),
+        arch="amd64",
+    )
+    second_metadata = snap_yaml.get_metadata_from_project(
+        project,
+        Path(new_dir),
+        arch="amd64",
+    )
+
+    assert first_metadata.environment is None
+    assert second_metadata.environment is None
+    assert project.environment == environment
+
+
 @pytest.mark.parametrize(
     "ld_library_path",
     [{}, {"LD_LIBRARY_PATH": None}, {"LD_LIBRARY_PATH": "test-ld-library-path"}],

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -25,7 +25,7 @@ from typing import Any, cast
 
 import pytest
 import yaml
-from craft_application import ServiceFactory
+from craft_application import ServiceFactory, util
 from craft_cli.pytest_plugin import RecordingEmitter
 from pytest_mock import MockerFixture
 
@@ -142,6 +142,55 @@ def test_write_metadata(default_project, fake_services, setup_project, new_dir):
     )
 
     assert not (prime_dir / "snap" / "manifest.yaml").exists()
+
+
+def test_get_snap_yaml(default_project, fake_services, setup_project):
+    setup_project(fake_services, default_project.marshal())
+    package_service = fake_services.get("package")
+
+    assert package_service._get_snap_yaml() == util.dump_yaml(
+        package_service.metadata.marshal()
+    )
+
+
+def test_get_artifacts(default_project, fake_services, setup_project, tmp_path):
+    setup_project(fake_services, default_project.marshal())
+    package_service = fake_services.get("package")
+    package_service.set_output_dir(tmp_path)
+
+    assert package_service.get_artifacts() == {
+        None: tmp_path / "default_1.0_amd64.snap"
+    }
+
+
+def test_pack_artifact(default_project, fake_services, setup_project, mocker, tmp_path):
+    setup_project(fake_services, default_project.marshal())
+    package_service = fake_services.get("package")
+    package_service.set_output_dir(tmp_path)
+
+    mock_pack_snap = mocker.patch.object(
+        pack, "pack_snap", return_value="default_1.0_amd64.snap"
+    )
+    mocker.patch.object(linters, "run_linters")
+    mocker.patch.object(linters, "report")
+
+    package_service._pack(path=tmp_path / "default_1.0_amd64.snap")
+
+    mock_pack_snap.assert_called_once_with(
+        tmp_path / "prime",
+        name="default",
+        version="1.0",
+        compression="xz",
+        output=str(tmp_path / "default_1.0_amd64.snap"),
+        target="amd64",
+    )
+
+
+def test_supports_conditional_repack(default_project, fake_services, setup_project):
+    setup_project(fake_services, default_project.marshal())
+    package_service = fake_services.get("package")
+
+    assert package_service.supports_conditional_repack is True
 
 
 def test_write_metadata_with_manifest(

--- a/tests/unit/services/test_package_components.py
+++ b/tests/unit/services/test_package_components.py
@@ -109,6 +109,44 @@ def test_pack(default_project, fake_services, setup_project, mocker):
 
 
 @pytest.mark.usefixtures("enable_partitions_feature")
+def test_get_artifacts(default_project, fake_services, setup_project, tmp_path):
+    setup_project(fake_services, default_project.marshal())
+    package_service = fake_services.get("package")
+    package_service.set_output_dir(tmp_path)
+
+    assert package_service.get_artifacts() == {
+        None: tmp_path / "default_1.0_amd64.snap",
+        "firstcomponent": tmp_path / "default+firstcomponent_1.0.comp",
+        "secondcomponent": tmp_path / "default+secondcomponent_1.0.comp",
+    }
+
+
+@pytest.mark.usefixtures("enable_partitions_feature")
+def test_pack_component_artifact(
+    default_project, fake_services, setup_project, mocker, tmp_path
+):
+    setup_project(fake_services, default_project.marshal())
+    package_service = fake_services.get("package")
+    package_service.set_output_dir(tmp_path)
+
+    mock_pack_component = mocker.patch.object(
+        pack, "pack_component", return_value="default+firstcomponent_1.0.comp"
+    )
+    mocker.patch.object(linters, "run_linters")
+    mocker.patch.object(linters, "report")
+
+    package_service._pack(
+        name="firstcomponent", path=tmp_path / "default+firstcomponent_1.0.comp"
+    )
+
+    mock_pack_component.assert_called_once_with(
+        tmp_path / "partitions/component/firstcomponent/prime",
+        compression="xz",
+        output_dir=tmp_path,
+    )
+
+
+@pytest.mark.usefixtures("enable_partitions_feature")
 def test_pack_component_compression(
     default_project, fake_services, setup_project, mocker
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -490,7 +490,7 @@ toml = [
 
 [[package]]
 name = "craft-application"
-version = "6.4.0"
+version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -512,9 +512,9 @@ dependencies = [
     { name = "snap-http" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/31/88/1a31a8085bf01ca5f00aeda88a5f5e4cff314fd4e56ee2a629f2c1d95ca3/craft_application-6.4.0.tar.gz", hash = "sha256:02b6afaaad0462f752c1c4715b6da4d7b7ee57bcd71b4ca38234cb18220a4354", size = 627605, upload-time = "2026-04-23T18:57:57.606Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/c3/be96c01c1b92a7a7eb6cafa881ccd09a6b9e1db1355835fc98f001680cc3/craft_application-7.1.0.tar.gz", hash = "sha256:e0a3fb2080bf1dd6daf8b570262716f79a5f307a87d3ed2b986eaca50e07efed", size = 663202, upload-time = "2026-07-07T22:02:40.491Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/21/38bf81b8327990d9b8a174abeddaf06f36434bfc924aaa275079627babf1/craft_application-6.4.0-py3-none-any.whl", hash = "sha256:ee587eaeb9570628a548189f81813f9517951ce367e87eb56ff01034f8dd59e9", size = 211843, upload-time = "2026-04-23T18:57:55.388Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ce/169bdacdfbda0fe8a880d914be0794fc5379b7ec577546444f1572f4762d/craft_application-7.1.0-py3-none-any.whl", hash = "sha256:3319310644d1d935fd7e2fb285fa38bc87c490f3d4fb72fed934e6202164b7bc", size = 212571, upload-time = "2026-07-07T22:02:38.317Z" },
 ]
 
 [package.optional-dependencies]
@@ -605,7 +605,7 @@ wheels = [
 
 [[package]]
 name = "craft-providers"
-version = "3.6.0"
+version = "3.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
@@ -615,9 +615,9 @@ dependencies = [
     { name = "requests" },
     { name = "requests-unixsocket2" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/bc/db06baf74ff9538282eb265f99b0147f3b8b775da583a9c6aa88a9d59227/craft_providers-3.6.0.tar.gz", hash = "sha256:dfffebb4a9f09f763b293fe396f9f4f17d917e18167d98b61f76cffd55556250", size = 325499, upload-time = "2026-04-30T17:43:56.728Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/f5/81525f63af39d73be1fae45fc169eb036781d745a0220f95d9b7f6165549/craft_providers-3.7.1.tar.gz", hash = "sha256:473e6228720dda9f042eae8b9584a1f1c41d6fd987c0fd9db0d69609d3c5f283", size = 380268, upload-time = "2026-07-02T14:03:49.44Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/88/a8cebf86e8fda0c542e70c40374d3edc0bf4cf92ba55151e3a4f60695253/craft_providers-3.6.0-py3-none-any.whl", hash = "sha256:3b3ee87e535f1a29555012ba8d050ae6ca9afbc91fc2f273656d57052a307854", size = 121782, upload-time = "2026-04-30T17:43:54.567Z" },
+    { url = "https://files.pythonhosted.org/packages/72/ba/c86bb1f2b356299f2971e613071bd30eef39719d372fb1e3f116b078d1ca/craft_providers-3.7.1-py3-none-any.whl", hash = "sha256:594efc39b84af865f4b3733b6658ec9e34ff6ff2bb98a1ed3785fe82d4afdc83", size = 120989, upload-time = "2026-07-02T14:03:47.659Z" },
 ]
 
 [[package]]
@@ -2518,7 +2518,7 @@ types = [
 requires-dist = [
     { name = "catkin-pkg", marker = "sys_platform == 'linux'", specifier = "==1.1.0" },
     { name = "click", specifier = ">=8.2" },
-    { name = "craft-application", extras = ["remote"], specifier = ">=6.4.0" },
+    { name = "craft-application", extras = ["remote"], specifier = ">=7.1.0" },
     { name = "craft-archives", specifier = ">=2.2.0" },
     { name = "craft-cli", specifier = ">=3.4.0" },
     { name = "craft-grammar", specifier = ">=2.3.0" },


### PR DESCRIPTION
Create the snap.yaml metadata file using the new packaging API to
skip repacking when the artifact contents are the same. This change
implements mediated file creation only for snap.yaml, other files
will he handled in separate PRs.

---

- [ ] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [ ] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
