### PR TITLE
fix: register dotnet 11 extension

### DIFF
--- a/snapcraft/commands/validations.py
+++ b/snapcraft/commands/validations.py
@@ -177,9 +177,8 @@ class StoreValidateCommand(AppCommand):
                 "%Y-%m-%dT%H:%M:%S.%fZ"
             )
 
-            # ty isn't aware of pydantic aliases (https://github.com/astral-sh/ty/issues/1438)
-            assertion = models.ValidationAssertion(  # ty: ignore[missing-argument]
-                assertion_type="validation",  # ty: ignore[unknown-argument]
+            assertion = models.ValidationAssertion(
+                assertion_type="validation",
                 authority_id=authority_id,
                 series=store.constants.DEFAULT_SERIES,
                 snap_id=snap_id,

--- a/snapcraft/extensions/registry.py
+++ b/snapcraft/extensions/registry.py
@@ -23,6 +23,7 @@ from snapcraft import errors
 from .dotnet8 import Dotnet8Extension
 from .dotnet9 import Dotnet9Extension
 from .dotnet10 import Dotnet10Extension
+from .dotnet11 import Dotnet11Extension
 from .env_injector import EnvInjector
 from .gnome import GNOME
 from .gpu_extension import GPUExtension
@@ -51,6 +52,7 @@ _EXTENSIONS: dict[str, "ExtensionType"] = {
     "dotnet8": Dotnet8Extension,
     "dotnet9": Dotnet9Extension,
     "dotnet10": Dotnet10Extension,
+    "dotnet11": Dotnet11Extension,
     "env-injector": EnvInjector,
     "gnome": GNOME,
     "gpu": GPUExtension,

--- a/tests/spread/extensions/dotnet/task.yaml
+++ b/tests/spread/extensions/dotnet/task.yaml
@@ -21,6 +21,7 @@ environment:
   DOTNET_RUNTIME_PLUG/dotnet9: dotnet9-runtime
   DOTNET_RUNTIME_PLUG/dotnet10: dotnet10-runtime
   DOTNET_RUNTIME_PLUG/dotnet11: dotnet11-runtime
+  SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS/dotnet11: 1
 
 restore: |
 

--- a/tests/unit/commands/test_list_extensions.py
+++ b/tests/unit/commands/test_list_extensions.py
@@ -36,6 +36,7 @@ def test_command(emitter, fake_app_config):
         Extension name         Supported bases
         ---------------------  ----------------------
         dotnet10               core24
+        dotnet11               core24
         dotnet8                core24
         dotnet9                core24
         env-injector           core24

--- a/tests/unit/extensions/test_registry.py
+++ b/tests/unit/extensions/test_registry.py
@@ -27,6 +27,7 @@ def test_get_extension_names():
         "dotnet8",
         "dotnet9",
         "dotnet10",
+        "dotnet11",
         "env-injector",
         "gnome",
         "gpu",

--- a/tests/unit/models/test_assertions.py
+++ b/tests/unit/models/test_assertions.py
@@ -364,8 +364,8 @@ class TestValidation:
 
     @pytest.fixture()
     def fake_validation_assertion(self):
-        return ValidationAssertion(  # ty: ignore[missing-argument]
-            assertion_type="validation",  # ty: ignore[unknown-argument]
+        return ValidationAssertion(
+            assertion_type="validation",
             authority_id="test-authority-id",
             series="16",
             snap_id="test-snap-id",
@@ -396,8 +396,8 @@ class TestValidation:
 
     def test_validation_marshal_as_str_exclude_revision(self):
         """Exclude revision when it's None."""
-        assertion = ValidationAssertion(  # ty: ignore[missing-argument]
-            assertion_type="validation",  # ty: ignore[unknown-argument]
+        assertion = ValidationAssertion(
+            assertion_type="validation",
             authority_id="test-authority-id",
             series="16",
             snap_id="test-snap-id",


### PR DESCRIPTION
I forgot to run the extended spread tests for #6321.

Also makes some fixes for the newest version of ty.

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
