### PR TITLE
fix(kde-neon-6): don't modify LD_LIBRARY_PATH

### DIFF
--- a/snapcraft/extensions/kde_neon_6.py
+++ b/snapcraft/extensions/kde_neon_6.py
@@ -214,7 +214,7 @@ class KDENeon6(GPUExtension):
             lxqt_support_snap: {
                 "content": lxqt_support_snap,
                 "interface": "content",
-                "target": f"$SNAP/{lxqt_support_snap}",
+                "target": "$SNAP/lxqt-support",
                 "default-provider": lxqt_support_snap,
             },
         }
@@ -222,14 +222,6 @@ class KDENeon6(GPUExtension):
             "SNAP_DESKTOP_RUNTIME": "$SNAP/kf6",
             "GTK_USE_PORTAL": "1",
             "PLATFORM_PLUG": platform_kf6_snap,
-            "LD_LIBRARY_PATH": (
-                f"$SNAP/{lxqt_support_snap}/usr/lib/"
-                "${CRAFT_ARCH_TRIPLET_BUILD_FOR}:${LD_LIBRARY_PATH}"
-            ),
-            "QT_PLUGIN_PATH": (
-                f"$SNAP/{lxqt_support_snap}/usr/lib/"
-                "${CRAFT_ARCH_TRIPLET_BUILD_FOR}/qt6/plugins:${QT_PLUGIN_PATH}"
-            ),
         }
         snippet["hooks"] = {
             "configure": {
@@ -245,12 +237,7 @@ class KDENeon6(GPUExtension):
             },
             "/usr/share/X11": {"symlink": "$SNAP/kf6/usr/share/X11"},
             "/usr/share/qt6": {"symlink": "$SNAP/kf6/usr/share/qt6"},
-            "/usr/share/color-schemes": {
-                "symlink": f"$SNAP/{lxqt_support_snap}/usr/share/color-schemes"
-            },
-            "/usr/share/Kvantum": {
-                "symlink": f"$SNAP/{lxqt_support_snap}/usr/share/Kvantum"
-            },
+            "/usr/share/Kvantum": {"symlink": "$SNAP/lxqt-support/usr/share/Kvantum"},
         }
         return snippet
 

--- a/tests/unit/extensions/test_kde_neon_6.py
+++ b/tests/unit/extensions/test_kde_neon_6.py
@@ -177,8 +177,6 @@ def test_get_root_snippet(kde_neon_6_extension):
             "SNAP_DESKTOP_RUNTIME": "$SNAP/kf6",
             "GTK_USE_PORTAL": "1",
             "PLATFORM_PLUG": "kf6-core22",
-            "LD_LIBRARY_PATH": "$SNAP/lxqt-support-core22/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}:${LD_LIBRARY_PATH}",
-            "QT_PLUGIN_PATH": "$SNAP/lxqt-support-core22/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/qt6/plugins:${QT_PLUGIN_PATH}",
         },
         "hooks": {
             "configure": {
@@ -190,12 +188,7 @@ def test_get_root_snippet(kde_neon_6_extension):
             "/usr/share/X11": {"symlink": "$SNAP/kf6/usr/share/X11"},
             "/usr/share/qt6": {"symlink": "$SNAP/kf6/usr/share/qt6"},
             "/usr/share/libdrm": {"bind": "$SNAP/kf6-core22/usr/share/libdrm"},
-            "/usr/share/Kvantum": {
-                "symlink": "$SNAP/lxqt-support-core22/usr/share/Kvantum"
-            },
-            "/usr/share/color-schemes": {
-                "symlink": "$SNAP/lxqt-support-core22/usr/share/color-schemes"
-            },
+            "/usr/share/Kvantum": {"symlink": "$SNAP/lxqt-support/usr/share/Kvantum"},
         },
         "plugs": {
             "desktop": {"mount-host-font-cache": False},
@@ -229,7 +222,7 @@ def test_get_root_snippet(kde_neon_6_extension):
                 "content": "lxqt-support-core22",
                 "interface": "content",
                 "default-provider": "lxqt-support-core22",
-                "target": "$SNAP/lxqt-support-core22",
+                "target": "$SNAP/lxqt-support",
             },
         },
     }
@@ -243,8 +236,6 @@ def test_get_root_snippet_core24(kde_neon_6_extension_core24):
             "SNAP_DESKTOP_RUNTIME": "$SNAP/kf6",
             "GTK_USE_PORTAL": "1",
             "PLATFORM_PLUG": "kf6-core24",
-            "LD_LIBRARY_PATH": "$SNAP/lxqt-support-core24/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}:${LD_LIBRARY_PATH}",
-            "QT_PLUGIN_PATH": "$SNAP/lxqt-support-core24/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/qt6/plugins:${QT_PLUGIN_PATH}",
         },
         "hooks": {
             "configure": {
@@ -257,12 +248,7 @@ def test_get_root_snippet_core24(kde_neon_6_extension_core24):
             "/usr/share/qt6": {"symlink": "$SNAP/kf6/usr/share/qt6"},
             "/usr/share/libdrm": {"bind": "$SNAP/gpu-2404/libdrm"},
             "/usr/share/drirc.d": {"symlink": "$SNAP/gpu-2404/drirc.d"},
-            "/usr/share/Kvantum": {
-                "symlink": "$SNAP/lxqt-support-core24/usr/share/Kvantum"
-            },
-            "/usr/share/color-schemes": {
-                "symlink": "$SNAP/lxqt-support-core24/usr/share/color-schemes"
-            },
+            "/usr/share/Kvantum": {"symlink": "$SNAP/lxqt-support/usr/share/Kvantum"},
         },
         "plugs": {
             "desktop": {"mount-host-font-cache": False},
@@ -301,7 +287,7 @@ def test_get_root_snippet_core24(kde_neon_6_extension_core24):
                 "content": "lxqt-support-core24",
                 "interface": "content",
                 "default-provider": "lxqt-support-core24",
-                "target": "$SNAP/lxqt-support-core24",
+                "target": "$SNAP/lxqt-support",
             },
         },
     }
@@ -342,8 +328,6 @@ def test_get_root_snippet_with_external_sdk(kde_neon_6_extension_with_build_snap
             "SNAP_DESKTOP_RUNTIME": "$SNAP/kf6",
             "GTK_USE_PORTAL": "1",
             "PLATFORM_PLUG": "kf6-core22",
-            "LD_LIBRARY_PATH": "$SNAP/lxqt-support-core22/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}:${LD_LIBRARY_PATH}",
-            "QT_PLUGIN_PATH": "$SNAP/lxqt-support-core22/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/qt6/plugins:${QT_PLUGIN_PATH}",
         },
         "hooks": {
             "configure": {
@@ -355,12 +339,7 @@ def test_get_root_snippet_with_external_sdk(kde_neon_6_extension_with_build_snap
             "/usr/share/X11": {"symlink": "$SNAP/kf6/usr/share/X11"},
             "/usr/share/qt6": {"symlink": "$SNAP/kf6/usr/share/qt6"},
             "/usr/share/libdrm": {"bind": "$SNAP/kf6-core22/usr/share/libdrm"},
-            "/usr/share/Kvantum": {
-                "symlink": "$SNAP/lxqt-support-core22/usr/share/Kvantum"
-            },
-            "/usr/share/color-schemes": {
-                "symlink": "$SNAP/lxqt-support-core22/usr/share/color-schemes"
-            },
+            "/usr/share/Kvantum": {"symlink": "$SNAP/lxqt-support/usr/share/Kvantum"},
         },
         "plugs": {
             "desktop": {"mount-host-font-cache": False},
@@ -394,7 +373,7 @@ def test_get_root_snippet_with_external_sdk(kde_neon_6_extension_with_build_snap
                 "content": "lxqt-support-core22",
                 "interface": "content",
                 "default-provider": "lxqt-support-core22",
-                "target": "$SNAP/lxqt-support-core22",
+                "target": "$SNAP/lxqt-support",
             },
         },
     }
@@ -410,8 +389,6 @@ def test_get_root_snippet_with_external_sdk_core24(
             "SNAP_DESKTOP_RUNTIME": "$SNAP/kf6",
             "GTK_USE_PORTAL": "1",
             "PLATFORM_PLUG": "kf6-core24",
-            "LD_LIBRARY_PATH": "$SNAP/lxqt-support-core24/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}:${LD_LIBRARY_PATH}",
-            "QT_PLUGIN_PATH": "$SNAP/lxqt-support-core24/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/qt6/plugins:${QT_PLUGIN_PATH}",
         },
         "hooks": {
             "configure": {
@@ -424,12 +401,7 @@ def test_get_root_snippet_with_external_sdk_core24(
             "/usr/share/qt6": {"symlink": "$SNAP/kf6/usr/share/qt6"},
             "/usr/share/libdrm": {"bind": "$SNAP/gpu-2404/libdrm"},
             "/usr/share/drirc.d": {"symlink": "$SNAP/gpu-2404/drirc.d"},
-            "/usr/share/Kvantum": {
-                "symlink": "$SNAP/lxqt-support-core24/usr/share/Kvantum"
-            },
-            "/usr/share/color-schemes": {
-                "symlink": "$SNAP/lxqt-support-core24/usr/share/color-schemes"
-            },
+            "/usr/share/Kvantum": {"symlink": "$SNAP/lxqt-support/usr/share/Kvantum"},
         },
         "plugs": {
             "desktop": {"mount-host-font-cache": False},
@@ -468,7 +440,7 @@ def test_get_root_snippet_with_external_sdk_core24(
                 "content": "lxqt-support-core24",
                 "interface": "content",
                 "default-provider": "lxqt-support-core24",
-                "target": "$SNAP/lxqt-support-core24",
+                "target": "$SNAP/lxqt-support",
             },
         },
     }

--- a/uv.lock
+++ b/uv.lock
@@ -2519,7 +2519,7 @@ types = [
 requires-dist = [
     { name = "catkin-pkg", marker = "sys_platform == 'linux'", specifier = "==1.1.0" },
     { name = "click", specifier = ">=8.3.3" },
-    { name = "craft-application", extras = ["remote"], specifier = ">=6.4.0" },
+    { name = "craft-application", extras = ["remote"], specifier = ">=7.1.0" },
     { name = "craft-archives", specifier = ">=2.2.0" },
     { name = "craft-cli", specifier = ">=3.4.0" },
     { name = "craft-grammar", specifier = ">=2.3.0" },


### PR DESCRIPTION
Correctly applies #6016 onto `main`.

#6016 made a few fixes for the KDE extensions for Snapcraft 8:
- setting `LD_LIBRARY_PATH` and `QT_PLUGIN_PATH` in the launcher rather than in the `snapcraft.yaml`
- updating the lxqt-support content interface

These fixes weren't fully applied when merging from `hotfix/8.14` into `main` (https://github.com/canonical/snapcraft/pull/6104), so Snapcraft 9 never received the fixes.

Source: https://forum.snapcraft.io/t/call-for-testing-snapcraft-9-0/51348/23?u=mr_cal
Fixes #6327
(SNAPCRAFT-1365)

---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/snapcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
- [ ] In documents I changed, I [added a meta description](https://canonical-starflow.readthedocs-hosted.com/how-to/add-a-page-meta-description/) if one was missing.
- [ ] I've updated the relevant release notes.
